### PR TITLE
Memory issue

### DIFF
--- a/onnxruntime-sys/examples/c_api_sample.rs
+++ b/onnxruntime-sys/examples/c_api_sample.rs
@@ -12,10 +12,11 @@ fn main() {
     // initialize  enviroment...one enviroment per process
     // enviroment maintains thread pools and other state info
     let mut env_ptr: *mut OrtEnv = std::ptr::null_mut();
+    let env_name = std::ffi::CString::new("test").unwrap();
     let status = unsafe {
         g_ort.as_ref().unwrap().CreateEnv.unwrap()(
             OrtLoggingLevel_ORT_LOGGING_LEVEL_VERBOSE,
-            std::ffi::CString::new("test").unwrap().into_raw(), // FIXME: Memory leak, see https://doc.rust-lang.org/std/ffi/struct.CString.html#method.into_raw
+            env_name.as_ptr(),
             &mut env_ptr,
         )
     };
@@ -47,7 +48,7 @@ fn main() {
     // create session and load model into memory
     // using squeezenet version 1.3
     // https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.1-7.onnx
-    const MODEL_PATH: &str = "squeezenet.onnx";
+    let model_path = std::ffi::CString::new("squeezenet.onnx").unwrap();
 
     let mut session_ptr: *mut OrtSession = std::ptr::null_mut();
 
@@ -55,7 +56,7 @@ fn main() {
     let status = unsafe {
         g_ort.as_ref().unwrap().CreateSession.unwrap()(
             env_ptr,
-            std::ffi::CString::new(MODEL_PATH).unwrap().into_raw(),
+            model_path.as_ptr(),
             session_options_ptr,
             &mut session_ptr,
         )

--- a/onnxruntime-sys/examples/c_api_sample.rs
+++ b/onnxruntime-sys/examples/c_api_sample.rs
@@ -246,7 +246,6 @@ fn main() {
 
     // score model & input tensor, get back output tensor
 
-    // FIXME: This leaks!
     let input_node_names_cstring: Vec<std::ffi::CString> = input_node_names
         .into_iter()
         .map(|n| std::ffi::CString::new(n).unwrap())
@@ -257,7 +256,6 @@ fn main() {
         .collect();
     let input_node_names_ptr_ptr: *const *const i8 = input_node_names_ptr.as_ptr();
 
-    // FIXME: This leaks!
     let output_node_names_cstring: Vec<std::ffi::CString> = output_node_names
         .into_iter()
         .map(|n| std::ffi::CString::new(n.clone()).unwrap())

--- a/onnxruntime-sys/examples/c_api_sample.rs
+++ b/onnxruntime-sys/examples/c_api_sample.rs
@@ -307,10 +307,13 @@ fn main() {
     assert!((unsafe { *floatarr.offset(0) } - 0.000045).abs() < 1e-6);
 
     // score the model, and print scores for first 5 classes
+    // NOTE: The C ONNX Runtime allocated the array, we shouldn't drop the vec
+    //       but let C de-allocate instead.
     let floatarr_vec: Vec<f32> = unsafe { Vec::from_raw_parts(floatarr, 5, 5) };
     for i in 0..5 {
         println!("Score for class [{}] =  {}", i, floatarr_vec[i]);
     }
+    std::mem::forget(floatarr_vec);
 
     // Results should be as below...
     // Score for class[0] = 0.000045

--- a/onnxruntime-sys/examples/c_api_sample.rs
+++ b/onnxruntime-sys/examples/c_api_sample.rs
@@ -263,8 +263,8 @@ fn main() {
         .map(|n| std::ffi::CString::new(n.clone()).unwrap())
         .collect();
     let output_node_names_ptr: Vec<*const i8> = output_node_names_cstring
-        .into_iter()
-        .map(|n| n.into_raw() as *const i8)
+        .iter()
+        .map(|n| n.as_ptr() as *const i8)
         .collect();
     let output_node_names_ptr_ptr: *const *const i8 = output_node_names_ptr.as_ptr();
 


### PR DESCRIPTION
Fix all memory issues, at least in the Rust code (there is some more in onnxruntime, looks like caused by logging).

```txt
❯ valgrind --leak-check=full target/debug/examples/c_api_sample
==57034== Memcheck, a memory error detector
==57034== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==57034== Using Valgrind-3.17.0.GIT and LibVEX; rerun with -h for copyright info
==57034== Command: target/debug/examples/c_api_sample
==57034==
Using Onnxruntime C API
--57034-- UNKNOWN mach_msg unhandled MACH_SEND_TRAILER option
--57034-- UNKNOWN mach_msg unhandled MACH_SEND_TRAILER option (repeated 2 times)
--57034-- UNKNOWN mach_msg unhandled MACH_SEND_TRAILER option (repeated 4 times)
2020-08-05 11:18:51.833064 [I:onnxruntime:, inference_session.cc:174 ConstructorCommon] Creating and using per session threadpools since use_per_session_threads_ is true
2020-08-05 11:18:53.808152 [I:onnxruntime:, inference_session.cc:830 Initialize] Initializing session.
2020-08-05 11:18:53.818594 [I:onnxruntime:, inference_session.cc:848 Initialize] Adding default CPU execution provider.
2020-08-05 11:18:53.875984 [I:onnxruntime:test, bfc_arena.cc:15 BFCArena] Creating BFCArena for Cpu
2020-08-05 11:18:53.880237 [V:onnxruntime:test, bfc_arena.cc:32 BFCArena] Creating 21 bins of max chunk size 256 to 268435456
2020-08-05 11:18:56.016417 [I:onnxruntime:, reshape_fusion.cc:37 ApplyImpl] Total fused reshape node count: 0
2020-08-05 11:18:56.360927 [I:onnxruntime:, reshape_fusion.cc:37 ApplyImpl] Total fused reshape node count: 0
2020-08-05 11:18:56.563632 [I:onnxruntime:, reshape_fusion.cc:37 ApplyImpl] Total fused reshape node count: 0
2020-08-05 11:18:56.737163 [V:onnxruntime:, inference_session.cc:671 TransformGraph] Node placements
2020-08-05 11:18:56.740553 [V:onnxruntime:, inference_session.cc:673 TransformGraph] All nodes have been placed on [CPUExecutionProvider].
2020-08-05 11:18:56.771621 [I:onnxruntime:, session_state.cc:25 SetGraph] SaveMLValueNameIndexMapping
2020-08-05 11:18:56.826579 [I:onnxruntime:, session_state.cc:70 SetGraph] Done saving OrtValue mappings.
2020-08-05 11:18:57.341654 [I:onnxruntime:, session_state_initializer.cc:178 SaveInitializedTensors] Saving initialized tensors.
2020-08-05 11:18:57.707040 [I:onnxruntime:, session_state_initializer.cc:223 SaveInitializedTensors] Done saving initialized tensors
2020-08-05 11:18:58.066134 [I:onnxruntime:, inference_session.cc:919 Initialize] Session successfully initialized.
Number of inputs = 1
Input 0 : name=data_0
Input 0 : type=1
Input 0 : num_dims=4
Input 0 : dim 0=1
Input 0 : dim 1=3
Input 0 : dim 2=224
Input 0 : dim 3=224
2020-08-05 11:18:58.805963 [I:onnxruntime:, sequential_executor.cc:145 Execute] Begin execution
2020-08-05 11:18:58.870080 [I:onnxruntime:test, bfc_arena.cc:259 AllocateRawInternal] Extending BFCArena for Cpu. bin_num:13 rounded_bytes:3154176
2020-08-05 11:18:58.875015 [I:onnxruntime:test, bfc_arena.cc:143 Extend] Extended allocation by 4194304 bytes.
2020-08-05 11:18:58.876616 [I:onnxruntime:test, bfc_arena.cc:147 Extend] Total allocated bytes: 9137152
2020-08-05 11:18:58.880891 [I:onnxruntime:test, bfc_arena.cc:150 Extend] Allocated memory at 0x10219d080 to 0x10259d080
2020-08-05 11:18:58.957582 [I:onnxruntime:test, bfc_arena.cc:259 AllocateRawInternal] Extending BFCArena for Cpu. bin_num:8 rounded_bytes:65536
2020-08-05 11:18:58.958493 [I:onnxruntime:test, bfc_arena.cc:143 Extend] Extended allocation by 4194304 bytes.
2020-08-05 11:18:58.959370 [I:onnxruntime:test, bfc_arena.cc:147 Extend] Total allocated bytes: 13331456
2020-08-05 11:18:58.960349 [I:onnxruntime:test, bfc_arena.cc:150 Extend] Allocated memory at 0x10259e080 to 0x10299e080
Score for class [0] =  0.000045440644
Score for class [1] =  0.0038458651
Score for class [2] =  0.00012494653
Score for class [3] =  0.0011804523
Score for class [4] =  0.0013169361
Done!
==57034==
==57034== HEAP SUMMARY:
==57034==     in use at exit: 55,441 bytes in 192 blocks
==57034==   total heap usage: 77,651 allocs, 77,459 frees, 28,331,033 bytes allocated
==57034==
==57034== 30 bytes in 1 blocks are possibly lost in loss record 7 of 68
==57034==    at 0x1001A7635: malloc (in /usr/local/Cellar/valgrind/HEAD-e0af3eb/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==57034==    by 0x10055CCE5: strdup (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x100721391: notify_monitor_file (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x100556A14: notify_register_tz (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x100558E10: gmt_init (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x1007A87E4: __pthread_once_handler (in /usr/lib/system/libsystem_pthread.dylib)
==57034==    by 0x100793EC6: _os_once_callout (in /usr/lib/system/libsystem_platform.dylib)
==57034==    by 0x1007A8792: pthread_once (in /usr/lib/system/libsystem_pthread.dylib)
==57034==    by 0x100557B78: gmtsub (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x105C60851: onnxruntime::logging::InitLocaltimeOffset(std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l> > > const&) (onnxruntime/core/common/logging/logging.cc:175)
==57034==    by 0x105C607C1: onnxruntime::logging::LoggingManager::GetEpochs() (onnxruntime/core/common/logging/logging.cc:79)
==57034==    by 0x105C61353: onnxruntime::logging::LoggingManager::GetTimestamp() const (include/onnxruntime/core/common/logging/logging.h:329)
==57034==
==57034== 32 bytes in 1 blocks are possibly lost in loss record 17 of 68
==57034==    at 0x1001A7C90: calloc (in /usr/local/Cellar/valgrind/HEAD-e0af3eb/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==57034==    by 0x1008805F3: objc::DenseMap<objc_class*, objc_class*, objc::DenseMapValueInfo<objc_class*>, objc::DenseMapInfo<objc_class*>, objc::detail::DenseMapPair<objc_class*, objc_class*> >::grow(unsigned int) (in /usr/lib/libobjc.A.dylib)
==57034==    by 0x1008804BA: addRemappedClass(objc_class*, objc_class*) (in /usr/lib/libobjc.A.dylib)
==57034==    by 0x100870C43: allocateBuckets(unsigned int) (in /usr/lib/libobjc.A.dylib)
==57034==    by 0x100870398: lookUpImpOrForward (in /usr/lib/libobjc.A.dylib)
==57034==    by 0x10080CF99: _xpc_payload_alloc (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x10080CE65: _xpc_payload_create_from_mach_msg (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x10080CD22: xpc_receive_mach_msg (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x100826B8A: _xpc_pipe_routine (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x10080BB61: xpc_pipe_routine_with_flags (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x10080B9E1: _xpc_interface_routine (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x10080DCE7: bootstrap_look_up3 (in /usr/lib/system/libxpc.dylib)
==57034==
==57034== 32 bytes in 1 blocks are possibly lost in loss record 18 of 68
==57034==    at 0x1001A7C90: calloc (in /usr/local/Cellar/valgrind/HEAD-e0af3eb/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==57034==    by 0x1008805F3: objc::DenseMap<objc_class*, objc_class*, objc::DenseMapValueInfo<objc_class*>, objc::DenseMapInfo<objc_class*>, objc::detail::DenseMapPair<objc_class*, objc_class*> >::grow(unsigned int) (in /usr/lib/libobjc.A.dylib)
==57034==    by 0x1008804BA: addRemappedClass(objc_class*, objc_class*) (in /usr/lib/libobjc.A.dylib)
==57034==    by 0x10087FFF3: realizeClassWithoutSwift(objc_class*, objc_class*) (in /usr/lib/libobjc.A.dylib)
==57034==    by 0x100870D44: -[NSObject dealloc] (in /usr/lib/libobjc.A.dylib)
==57034==    by 0x100870398: lookUpImpOrForward (in /usr/lib/libobjc.A.dylib)
==57034==    by 0x10080CF99: _xpc_payload_alloc (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x10080CE65: _xpc_payload_create_from_mach_msg (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x10080CD22: xpc_receive_mach_msg (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x100826B8A: _xpc_pipe_routine (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x10080BB61: xpc_pipe_routine_with_flags (in /usr/lib/system/libxpc.dylib)
==57034==    by 0x10080B9E1: _xpc_interface_routine (in /usr/lib/system/libxpc.dylib)
==57034==
==57034== 56 bytes in 1 blocks are possibly lost in loss record 21 of 68
==57034==    at 0x1001A7C90: calloc (in /usr/local/Cellar/valgrind/HEAD-e0af3eb/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==57034==    by 0x100724190: _notify_fork_child (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x1007243A0: _notify_fork_child (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x10071EA6B: notify_register_check (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x1005569ED: notify_register_tz (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x10055635F: tzsetwall_basic (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x1005581A3: localtime_r (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x105C6083C: onnxruntime::logging::InitLocaltimeOffset(std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l> > > const&) (onnxruntime/core/common/logging/logging.cc:174)
==57034==    by 0x105C607C1: onnxruntime::logging::LoggingManager::GetEpochs() (onnxruntime/core/common/logging/logging.cc:79)
==57034==    by 0x105C61353: onnxruntime::logging::LoggingManager::GetTimestamp() const (include/onnxruntime/core/common/logging/logging.h:329)
==57034==    by 0x105C6126E: onnxruntime::logging::LoggingManager::Log(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, onnxruntime::logging::Capture const&) const (onnxruntime/core/common/logging/logging.cc:153)
==57034==    by 0x105C5F838: onnxruntime::logging::Logger::Log(onnxruntime::logging::Capture const&) const (include/onnxruntime/core/common/logging/logging.h:291)
==57034==
==57034== 56 bytes in 1 blocks are possibly lost in loss record 22 of 68
==57034==    at 0x1001A7C90: calloc (in /usr/local/Cellar/valgrind/HEAD-e0af3eb/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==57034==    by 0x100724190: _notify_fork_child (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x1007243A0: _notify_fork_child (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x10071EA6B: notify_register_check (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x1005569ED: notify_register_tz (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x100558E10: gmt_init (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x1007A87E4: __pthread_once_handler (in /usr/lib/system/libsystem_pthread.dylib)
==57034==    by 0x100793EC6: _os_once_callout (in /usr/lib/system/libsystem_platform.dylib)
==57034==    by 0x1007A8792: pthread_once (in /usr/lib/system/libsystem_pthread.dylib)
==57034==    by 0x100557B78: gmtsub (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x105C60851: onnxruntime::logging::InitLocaltimeOffset(std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l> > > const&) (onnxruntime/core/common/logging/logging.cc:175)
==57034==    by 0x105C607C1: onnxruntime::logging::LoggingManager::GetEpochs() (onnxruntime/core/common/logging/logging.cc:79)
==57034==
==57034== 56 bytes in 1 blocks are possibly lost in loss record 23 of 68
==57034==    at 0x1001A7635: malloc (in /usr/local/Cellar/valgrind/HEAD-e0af3eb/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==57034==    by 0x1007241C5: _notify_fork_child (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x1007243A0: _notify_fork_child (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x10071EA6B: notify_register_check (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x1005569ED: notify_register_tz (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x100558E10: gmt_init (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x1007A87E4: __pthread_once_handler (in /usr/lib/system/libsystem_pthread.dylib)
==57034==    by 0x100793EC6: _os_once_callout (in /usr/lib/system/libsystem_platform.dylib)
==57034==    by 0x1007A8792: pthread_once (in /usr/lib/system/libsystem_pthread.dylib)
==57034==    by 0x100557B78: gmtsub (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x105C60851: onnxruntime::logging::InitLocaltimeOffset(std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l> > > const&) (onnxruntime/core/common/logging/logging.cc:175)
==57034==    by 0x105C607C1: onnxruntime::logging::LoggingManager::GetEpochs() (onnxruntime/core/common/logging/logging.cc:79)
==57034==
==57034== 112 bytes in 1 blocks are possibly lost in loss record 41 of 68
==57034==    at 0x1001A7C90: calloc (in /usr/local/Cellar/valgrind/HEAD-e0af3eb/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==57034==    by 0x1007243CC: _notify_fork_child (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x10071EA6B: notify_register_check (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x1005569ED: notify_register_tz (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x10055635F: tzsetwall_basic (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x1005581A3: localtime_r (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x105C6083C: onnxruntime::logging::InitLocaltimeOffset(std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l> > > const&) (onnxruntime/core/common/logging/logging.cc:174)
==57034==    by 0x105C607C1: onnxruntime::logging::LoggingManager::GetEpochs() (onnxruntime/core/common/logging/logging.cc:79)
==57034==    by 0x105C61353: onnxruntime::logging::LoggingManager::GetTimestamp() const (include/onnxruntime/core/common/logging/logging.h:329)
==57034==    by 0x105C6126E: onnxruntime::logging::LoggingManager::Log(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, onnxruntime::logging::Capture const&) const (onnxruntime/core/common/logging/logging.cc:153)
==57034==    by 0x105C5F838: onnxruntime::logging::Logger::Log(onnxruntime::logging::Capture const&) const (include/onnxruntime/core/common/logging/logging.h:291)
==57034==    by 0x105C5F79C: onnxruntime::logging::Capture::~Capture() (onnxruntime/core/common/logging/capture.cc:57)
==57034==
==57034== 112 bytes in 1 blocks are possibly lost in loss record 42 of 68
==57034==    at 0x1001A7C90: calloc (in /usr/local/Cellar/valgrind/HEAD-e0af3eb/lib/valgrind/vgpreload_memcheck-amd64-darwin.so)
==57034==    by 0x1007243CC: _notify_fork_child (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x10071EA6B: notify_register_check (in /usr/lib/system/libsystem_notify.dylib)
==57034==    by 0x1005569ED: notify_register_tz (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x100558E10: gmt_init (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x1007A87E4: __pthread_once_handler (in /usr/lib/system/libsystem_pthread.dylib)
==57034==    by 0x100793EC6: _os_once_callout (in /usr/lib/system/libsystem_platform.dylib)
==57034==    by 0x1007A8792: pthread_once (in /usr/lib/system/libsystem_pthread.dylib)
==57034==    by 0x100557B78: gmtsub (in /usr/lib/system/libsystem_c.dylib)
==57034==    by 0x105C60851: onnxruntime::logging::InitLocaltimeOffset(std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000l> > > const&) (onnxruntime/core/common/logging/logging.cc:175)
==57034==    by 0x105C607C1: onnxruntime::logging::LoggingManager::GetEpochs() (onnxruntime/core/common/logging/logging.cc:79)
==57034==    by 0x105C61353: onnxruntime::logging::LoggingManager::GetTimestamp() const (include/onnxruntime/core/common/logging/logging.h:329)
==57034==
==57034== LEAK SUMMARY:
==57034==    definitely lost: 0 bytes in 0 blocks
==57034==    indirectly lost: 0 bytes in 0 blocks
==57034==      possibly lost: 486 bytes in 8 blocks
==57034==    still reachable: 40,681 bytes in 22 blocks
==57034==                       of which reachable via heuristic:
==57034==                         newarray           : 56 bytes in 1 blocks
==57034==         suppressed: 14,274 bytes in 162 blocks
==57034== Reachable blocks (those to which a pointer was found) are not shown.
==57034== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==57034==
==57034== For lists of detected and suppressed errors, rerun with: -s
==57034== ERROR SUMMARY: 8 errors from 8 contexts (suppressed: 9 from 9)
```

Closes #3.
