### PR TITLE
Build script

### DIFF
--- a/onnxruntime-sys/Cargo.toml
+++ b/onnxruntime-sys/Cargo.toml
@@ -18,3 +18,11 @@ keywords = ["neuralnetworks", "onnx", "bindings"]
 
 [build-dependencies]
 bindgen = "0.54"
+ureq = "1.3"
+
+[target.'cfg(windows)'.build-dependencies]
+zip = "0.5"
+
+[target.'cfg(unix)'.build-dependencies]
+flate2 = "1.0"
+tar = "0.4"


### PR DESCRIPTION
Modify build script to support multiple strategies:

* "download": Download a pre-built library from upstream. This is the default if `ORT_STRATEGY` is not set.
* "system": Use installed library. Use `ORT_LIB_LOCATION` to point to proper location.
* "compile": Download source and compile (TODO).

The build script was inspired from one adapted by @elslooo
from the one by @LaurentMazare used in tch-rs.

Some modifications from the one in tch-rs:
* There is a single CUDA version supported so no need to select which one
* Dependencies are changed to minimize them (`ureq` to HTTP download)
* Dependencies are different on Windows and Unix since the prebuilt
  archives have different format (zip on Windows, tar.gz on Unix).
  Instead of building them both on all platforms, the dependencies are
  only compiled on the required platforms. This prevents cross-compilation
  Windows <--> Unix but that should not be a huge issue, at least for now.

Reference:
https://github.com/LaurentMazare/tch-rs/blob/bc312713ec55fa15058a661c0ada628d7d423db1/torch-sys/build.rs

Closes #6.