### PR TITLE
Fetch model feature

### DIFF
--- a/onnxruntime/Cargo.toml
+++ b/onnxruntime/Cargo.toml
@@ -20,6 +20,8 @@ ndarray = "0.13"
 onnxruntime-sys = {version = "0.0.5", path = "../onnxruntime-sys"}
 thiserror = "1.0"
 
+ureq = "1.3"
+
 [features]
 # Disable build script; used by https://docs.rs
 disable-bindgen = ["onnxruntime-sys/disable-bindgen"]

--- a/onnxruntime/Cargo.toml
+++ b/onnxruntime/Cargo.toml
@@ -14,15 +14,22 @@ repository = "https://github.com/nbigaouette/onnxruntime-rs"
 categories = ["science"]
 keywords = ["neuralnetworks", "onnx", "bindings"]
 
+[[example]]
+name = "sample"
+required-features = ["model-fetching"]
+
 [dependencies]
 lazy_static = "1.4"
 ndarray = "0.13"
 onnxruntime-sys = {version = "0.0.5", path = "../onnxruntime-sys"}
 thiserror = "1.0"
 
-ureq = "1.3"
+# Enabled with 'model-fetching' feature
+ureq = {version = "1.3", optional = true}
 
 [features]
+# Fetch model from ONNX Model Zoo (https://github.com/onnx/models)
+model-fetching = ["ureq"]
 # Disable build script; used by https://docs.rs
 disable-bindgen = ["onnxruntime-sys/disable-bindgen"]
 

--- a/onnxruntime/examples/sample.rs
+++ b/onnxruntime/examples/sample.rs
@@ -2,7 +2,9 @@
 
 use ndarray::Array;
 
-use onnxruntime::{env::Env, GraphOptimizationLevel, LoggingLevel};
+use onnxruntime::{
+    download::ImageClassificationModel, env::Env, GraphOptimizationLevel, LoggingLevel,
+};
 
 type Error = Box<dyn std::error::Error>;
 
@@ -23,7 +25,9 @@ fn run() -> Result<(), Error> {
         .new_session_builder()?
         .with_optimization_level(GraphOptimizationLevel::Basic)?
         .with_number_threads(1)?
-        .load_model_from_file("squeezenet.onnx")?;
+        // .load_model_from_file("squeezenet.onnx")?;
+        // .with_downloaded_model(ImageClassificationModel::MobileNet)?;
+        .with_downloaded_model(ImageClassificationModel::SqueezeNet)?;
 
     let input0_shape: Vec<usize> = session.inputs[0].dimensions().collect();
     let output0_shape: Vec<usize> = session.outputs[0].dimensions().collect();

--- a/onnxruntime/examples/sample.rs
+++ b/onnxruntime/examples/sample.rs
@@ -2,7 +2,7 @@
 
 use ndarray::Array;
 
-use onnxruntime::{EnvBuilder, GraphOptimizationLevel, LoggingLevel};
+use onnxruntime::{env::Env, GraphOptimizationLevel, LoggingLevel};
 
 type Error = Box<dyn std::error::Error>;
 
@@ -14,7 +14,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Error> {
-    let env = EnvBuilder::new()
+    let env = Env::builder()
         .with_name("test")
         .with_log_level(LoggingLevel::Verbose)
         .build()?;

--- a/onnxruntime/examples/sample.rs
+++ b/onnxruntime/examples/sample.rs
@@ -3,7 +3,7 @@
 use ndarray::Array;
 
 use onnxruntime::{
-    download::ImageClassificationModel, env::Env, GraphOptimizationLevel, LoggingLevel,
+    download::vision::ImageClassificationModel, env::Env, GraphOptimizationLevel, LoggingLevel,
 };
 
 type Error = Box<dyn std::error::Error>;

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -126,6 +126,20 @@ impl ModelUrl for InceptionVersion {
     }
 }
 
+impl From<ImageClassificationModel> for AvailableOnnxModel {
+    fn from(model: ImageClassificationModel) -> Self {
+        AvailableOnnxModel::Vision(Vision::ImageClassification(model))
+    }
+}
+
+impl From<InceptionVersion> for AvailableOnnxModel {
+    fn from(model: InceptionVersion) -> Self {
+        AvailableOnnxModel::Vision(Vision::ImageClassification(
+            ImageClassificationModel::Inception(model),
+        ))
+    }
+}
+
 impl AvailableOnnxModel {
     pub(crate) fn download_to<P>(&self, download_dir: P) -> Result<PathBuf>
     where

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -1,0 +1,87 @@
+//! Module controlling models downloadable from ONNX Model Zoom
+//!
+//! Pre-trained models are available from the
+//! [ONNX Model Zoo](https://github.com/onnx/models).
+//!
+//! A pre-trained model can be downloaded automatically using the
+//! [`SessionBuilder`](../session/struct.SessionBuilder.html)'s
+//! [`with_downloaded_model()`](../session/struct.SessionBuilder.html#method.with_downloaded_model) method.
+//!
+//! See [`AvailableOnnxModel`](enum.AvailableOnnxModel.html) for the different models available
+//! to download.
+
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use crate::error::{OrtDownloadError, Result};
+
+/// Available pre-trained models to download from [ONNX Model Zoo](https://github.com/onnx/models).
+///
+/// According to [ONNX Model Zoo](https://github.com/onnx/models)'s GitHub page:
+///
+/// > The ONNX Model Zoo is a collection of pre-trained, state-of-the-art models in the ONNX format
+/// > contributed by community members like you.
+#[derive(Debug, Clone)]
+pub enum AvailableOnnxModel {
+    /// A small CNN with AlexNet level accuracy on ImageNet with 50x fewer parameters.
+    ///
+    /// > SqueezeNet is a small CNN which achieves AlexNet level accuracy on ImageNet with 50x fewer parameters.
+    /// > SqueezeNet requires less communication across servers during distributed training, less bandwidth to
+    /// > export a new model from the cloud to an autonomous car and more feasible to deploy on FPGAs and other
+    /// > hardware with limited memory.
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/squeezenet](https://github.com/onnx/models/tree/master/vision/classification/squeezenet)
+    ///
+    /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
+    SqueezeNet,
+}
+
+impl AvailableOnnxModel {
+    fn fetch_url(&self) -> &'static str {
+        match self {
+            AvailableOnnxModel::SqueezeNet => "https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.0-9.onnx",
+        }
+    }
+
+    pub(crate) fn download_to<P>(&self, download_dir: P) -> Result<PathBuf>
+    where
+        P: AsRef<Path>,
+    {
+        let url = self.fetch_url();
+
+        let model_filename = PathBuf::from(url.split('/').last().unwrap());
+        let model_filepath = download_dir.as_ref().join(model_filename);
+
+        let resp = ureq::get(url)
+            .timeout_connect(1_000) // 1 second
+            .timeout(Duration::from_secs(180)) // 3 minutes
+            .call();
+
+        assert!(resp.has("Content-Length"));
+        let len = resp
+            .header("Content-Length")
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap();
+
+        let mut reader = resp.into_reader();
+
+        let f = fs::File::create(&model_filepath).unwrap();
+        let mut writer = io::BufWriter::new(f);
+
+        let bytes_io_count =
+            io::copy(&mut reader, &mut writer).map_err(OrtDownloadError::IoError)?;
+
+        if bytes_io_count == len as u64 {
+            Ok(model_filepath)
+        } else {
+            Err(OrtDownloadError::CopyError {
+                expected: len as u64,
+                io: bytes_io_count,
+            }
+            .into())
+        }
+    }
+}

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -27,7 +27,7 @@ use crate::error::{OrtDownloadError, Result};
 #[derive(Debug, Clone)]
 pub enum AvailableOnnxModel {
     /// Computer vision model
-    Vision(VisionModel),
+    Vision(Vision),
 }
 
 trait ModelUrl {
@@ -36,7 +36,7 @@ trait ModelUrl {
 
 /// Computer vision model
 #[derive(Debug, Clone)]
-pub enum VisionModel {
+pub enum Vision {
     /// Image classification model
     ImageClassification(ImageClassificationModel),
 }
@@ -99,10 +99,10 @@ impl ModelUrl for AvailableOnnxModel {
     }
 }
 
-impl ModelUrl for VisionModel {
+impl ModelUrl for Vision {
     fn fetch_url(&self) -> &'static str {
         match self {
-            VisionModel::ImageClassification(ic) => ic.fetch_url(),
+            Vision::ImageClassification(ic) => ic.fetch_url(),
         }
     }
 }

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -48,16 +48,51 @@ pub enum AvailableOnnxModel {
     ///
     /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
     SqueezeNet,
+    /// Google's Inception
+    Inception(Inception),
 }
 
-impl AvailableOnnxModel {
+trait ModelUrl {
+    fn fetch_url(&self) -> &'static str;
+}
+
+/// Google's Inception
+#[derive(Debug, Clone)]
+pub enum Inception {
+    /// Google's Inception v1
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v1](https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v1)
+    ///
+    /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
+    V1,
+    /// Google's Inception v2
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v2](https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v2)
+    ///
+    /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
+    V2,
+}
+
+impl ModelUrl for AvailableOnnxModel {
     fn fetch_url(&self) -> &'static str {
         match self {
             AvailableOnnxModel::MobileNet => "https://github.com/onnx/models/raw/master/vision/classification/mobilenet/model/mobilenetv2-7.onnx",
             AvailableOnnxModel::SqueezeNet => "https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.0-9.onnx",
+            AvailableOnnxModel::Inception(version) => version.fetch_url(),
         }
     }
+}
 
+impl ModelUrl for Inception {
+    fn fetch_url(&self) -> &'static str {
+        match self {
+            Inception::V1 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx",
+            Inception::V2 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx",
+        }
+    }
+}
+
+impl AvailableOnnxModel {
     pub(crate) fn download_to<P>(&self, download_dir: P) -> Result<PathBuf>
     where
         P: AsRef<Path>,

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -48,6 +48,12 @@ pub enum Vision {
 /// Source: [https://github.com/onnx/models#image-classification-](https://github.com/onnx/models#image-classification-)
 #[derive(Debug, Clone)]
 pub enum ImageClassificationModel {
+    /// Handwritten digits prediction using CNN
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/mnist](https://github.com/onnx/models/tree/master/vision/classification/mnist)
+    ///
+    /// Variant downloaded: ONNX Version 1.3 with Opset Version 8.
+    Mnist,
     /// Image classification aimed for mobile targets.
     ///
     /// > MobileNet models perform image classification - they take images as input and classify the major
@@ -110,6 +116,7 @@ impl ModelUrl for Vision {
 impl ModelUrl for ImageClassificationModel {
     fn fetch_url(&self) -> &'static str {
         match self {
+            ImageClassificationModel::Mnist => "https://github.com/onnx/models/raw/master/vision/classification/mnist/model/mnist-8.onnx",
             ImageClassificationModel::MobileNet => "https://github.com/onnx/models/raw/master/vision/classification/mobilenet/model/mobilenetv2-7.onnx",
             ImageClassificationModel::SqueezeNet => "https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.0-9.onnx",
             ImageClassificationModel::Inception(version) => version.fetch_url(),

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -49,7 +49,7 @@ pub enum AvailableOnnxModel {
     /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
     SqueezeNet,
     /// Google's Inception
-    Inception(Inception),
+    Inception(InceptionVersion),
 }
 
 trait ModelUrl {
@@ -58,7 +58,7 @@ trait ModelUrl {
 
 /// Google's Inception
 #[derive(Debug, Clone)]
-pub enum Inception {
+pub enum InceptionVersion {
     /// Google's Inception v1
     ///
     /// Source: [https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v1](https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v1)
@@ -83,11 +83,11 @@ impl ModelUrl for AvailableOnnxModel {
     }
 }
 
-impl ModelUrl for Inception {
+impl ModelUrl for InceptionVersion {
     fn fetch_url(&self) -> &'static str {
         match self {
-            Inception::V1 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx",
-            Inception::V2 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx",
+            InceptionVersion::V1 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx",
+            InceptionVersion::V2 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx",
         }
     }
 }

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -17,6 +17,9 @@ use std::{
 };
 
 use crate::error::{OrtDownloadError, Result};
+use vision::{ImageClassificationModel, InceptionVersion, Vision};
+
+pub mod vision;
 
 /// Available pre-trained models to download from [ONNX Model Zoo](https://github.com/onnx/models).
 ///
@@ -27,74 +30,11 @@ use crate::error::{OrtDownloadError, Result};
 #[derive(Debug, Clone)]
 pub enum AvailableOnnxModel {
     /// Computer vision model
-    Vision(Vision),
+    Vision(vision::Vision),
 }
 
 trait ModelUrl {
     fn fetch_url(&self) -> &'static str;
-}
-
-/// Computer vision model
-#[derive(Debug, Clone)]
-pub enum Vision {
-    /// Image classification model
-    ImageClassification(ImageClassificationModel),
-}
-/// Image classification model
-///
-/// > This collection of models take images as input, then classifies the major objects in the images
-/// > into 1000 object categories such as keyboard, mouse, pencil, and many animals.
-///
-/// Source: [https://github.com/onnx/models#image-classification-](https://github.com/onnx/models#image-classification-)
-#[derive(Debug, Clone)]
-pub enum ImageClassificationModel {
-    /// Handwritten digits prediction using CNN
-    ///
-    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/mnist](https://github.com/onnx/models/tree/master/vision/classification/mnist)
-    ///
-    /// Variant downloaded: ONNX Version 1.3 with Opset Version 8.
-    Mnist,
-    /// Image classification aimed for mobile targets.
-    ///
-    /// > MobileNet models perform image classification - they take images as input and classify the major
-    /// > object in the image into a set of pre-defined classes. They are trained on ImageNet dataset which
-    /// > contains images from 1000 classes. MobileNet models are also very efficient in terms of speed and
-    /// > size and hence are ideal for embedded and mobile applications.
-    ///
-    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/mobilenet](https://github.com/onnx/models/tree/master/vision/classification/mobilenet)
-    ///
-    /// Variant downloaded: ONNX Version 1.2.1 with Opset Version 7.
-    MobileNet,
-    /// A small CNN with AlexNet level accuracy on ImageNet with 50x fewer parameters.
-    ///
-    /// > SqueezeNet is a small CNN which achieves AlexNet level accuracy on ImageNet with 50x fewer parameters.
-    /// > SqueezeNet requires less communication across servers during distributed training, less bandwidth to
-    /// > export a new model from the cloud to an autonomous car and more feasible to deploy on FPGAs and other
-    /// > hardware with limited memory.
-    ///
-    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/squeezenet](https://github.com/onnx/models/tree/master/vision/classification/squeezenet)
-    ///
-    /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
-    SqueezeNet,
-    /// Google's Inception
-    Inception(InceptionVersion),
-}
-
-/// Google's Inception
-#[derive(Debug, Clone)]
-pub enum InceptionVersion {
-    /// Google's Inception v1
-    ///
-    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v1](https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v1)
-    ///
-    /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
-    V1,
-    /// Google's Inception v2
-    ///
-    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v2](https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v2)
-    ///
-    /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
-    V2,
 }
 
 impl ModelUrl for AvailableOnnxModel {
@@ -102,48 +42,6 @@ impl ModelUrl for AvailableOnnxModel {
         match self {
             AvailableOnnxModel::Vision(vision) => vision.fetch_url(),
         }
-    }
-}
-
-impl ModelUrl for Vision {
-    fn fetch_url(&self) -> &'static str {
-        match self {
-            Vision::ImageClassification(ic) => ic.fetch_url(),
-        }
-    }
-}
-
-impl ModelUrl for ImageClassificationModel {
-    fn fetch_url(&self) -> &'static str {
-        match self {
-            ImageClassificationModel::Mnist => "https://github.com/onnx/models/raw/master/vision/classification/mnist/model/mnist-8.onnx",
-            ImageClassificationModel::MobileNet => "https://github.com/onnx/models/raw/master/vision/classification/mobilenet/model/mobilenetv2-7.onnx",
-            ImageClassificationModel::SqueezeNet => "https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.0-9.onnx",
-            ImageClassificationModel::Inception(version) => version.fetch_url(),
-        }
-    }
-}
-
-impl ModelUrl for InceptionVersion {
-    fn fetch_url(&self) -> &'static str {
-        match self {
-            InceptionVersion::V1 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx",
-            InceptionVersion::V2 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx",
-        }
-    }
-}
-
-impl From<ImageClassificationModel> for AvailableOnnxModel {
-    fn from(model: ImageClassificationModel) -> Self {
-        AvailableOnnxModel::Vision(Vision::ImageClassification(model))
-    }
-}
-
-impl From<InceptionVersion> for AvailableOnnxModel {
-    fn from(model: InceptionVersion) -> Self {
-        AvailableOnnxModel::Vision(Vision::ImageClassification(
-            ImageClassificationModel::Inception(model),
-        ))
     }
 }
 
@@ -196,5 +94,19 @@ impl AvailableOnnxModel {
                 .into())
             }
         }
+    }
+}
+
+impl From<ImageClassificationModel> for AvailableOnnxModel {
+    fn from(model: ImageClassificationModel) -> Self {
+        AvailableOnnxModel::Vision(Vision::ImageClassification(model))
+    }
+}
+
+impl From<InceptionVersion> for AvailableOnnxModel {
+    fn from(model: InceptionVersion) -> Self {
+        AvailableOnnxModel::Vision(Vision::ImageClassification(
+            ImageClassificationModel::Inception(model),
+        ))
     }
 }

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -26,6 +26,28 @@ use crate::error::{OrtDownloadError, Result};
 /// > contributed by community members like you.
 #[derive(Debug, Clone)]
 pub enum AvailableOnnxModel {
+    /// Computer vision model
+    Vision(VisionModel),
+}
+
+trait ModelUrl {
+    fn fetch_url(&self) -> &'static str;
+}
+
+/// Computer vision model
+#[derive(Debug, Clone)]
+pub enum VisionModel {
+    /// Image classification model
+    ImageClassification(ImageClassificationModel),
+}
+/// Image classification model
+///
+/// > This collection of models take images as input, then classifies the major objects in the images
+/// > into 1000 object categories such as keyboard, mouse, pencil, and many animals.
+///
+/// Source: [https://github.com/onnx/models#image-classification-](https://github.com/onnx/models#image-classification-)
+#[derive(Debug, Clone)]
+pub enum ImageClassificationModel {
     /// Image classification aimed for mobile targets.
     ///
     /// > MobileNet models perform image classification - they take images as input and classify the major
@@ -52,10 +74,6 @@ pub enum AvailableOnnxModel {
     Inception(InceptionVersion),
 }
 
-trait ModelUrl {
-    fn fetch_url(&self) -> &'static str;
-}
-
 /// Google's Inception
 #[derive(Debug, Clone)]
 pub enum InceptionVersion {
@@ -76,9 +94,25 @@ pub enum InceptionVersion {
 impl ModelUrl for AvailableOnnxModel {
     fn fetch_url(&self) -> &'static str {
         match self {
-            AvailableOnnxModel::MobileNet => "https://github.com/onnx/models/raw/master/vision/classification/mobilenet/model/mobilenetv2-7.onnx",
-            AvailableOnnxModel::SqueezeNet => "https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.0-9.onnx",
-            AvailableOnnxModel::Inception(version) => version.fetch_url(),
+            AvailableOnnxModel::Vision(vision) => vision.fetch_url(),
+        }
+    }
+}
+
+impl ModelUrl for VisionModel {
+    fn fetch_url(&self) -> &'static str {
+        match self {
+            VisionModel::ImageClassification(ic) => ic.fetch_url(),
+        }
+    }
+}
+
+impl ModelUrl for ImageClassificationModel {
+    fn fetch_url(&self) -> &'static str {
+        match self {
+            ImageClassificationModel::MobileNet => "https://github.com/onnx/models/raw/master/vision/classification/mobilenet/model/mobilenetv2-7.onnx",
+            ImageClassificationModel::SqueezeNet => "https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.0-9.onnx",
+            ImageClassificationModel::Inception(version) => version.fetch_url(),
         }
     }
 }

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -46,6 +46,7 @@ impl ModelUrl for AvailableOnnxModel {
 }
 
 impl AvailableOnnxModel {
+    #[cfg(feature = "model-fetching")]
     pub(crate) fn download_to<P>(&self, download_dir: P) -> Result<PathBuf>
     where
         P: AsRef<Path>,

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -26,6 +26,17 @@ use crate::error::{OrtDownloadError, Result};
 /// > contributed by community members like you.
 #[derive(Debug, Clone)]
 pub enum AvailableOnnxModel {
+    /// Image classification aimed for mobile targets.
+    ///
+    /// > MobileNet models perform image classification - they take images as input and classify the major
+    /// > object in the image into a set of pre-defined classes. They are trained on ImageNet dataset which
+    /// > contains images from 1000 classes. MobileNet models are also very efficient in terms of speed and
+    /// > size and hence are ideal for embedded and mobile applications.
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/mobilenet](https://github.com/onnx/models/tree/master/vision/classification/mobilenet)
+    ///
+    /// Variant downloaded: ONNX Version 1.2.1 with Opset Version 7.
+    MobileNet,
     /// A small CNN with AlexNet level accuracy on ImageNet with 50x fewer parameters.
     ///
     /// > SqueezeNet is a small CNN which achieves AlexNet level accuracy on ImageNet with 50x fewer parameters.
@@ -42,6 +53,7 @@ pub enum AvailableOnnxModel {
 impl AvailableOnnxModel {
     fn fetch_url(&self) -> &'static str {
         match self {
+            AvailableOnnxModel::MobileNet => "https://github.com/onnx/models/raw/master/vision/classification/mobilenet/model/mobilenetv2-7.onnx",
             AvailableOnnxModel::SqueezeNet => "https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.0-9.onnx",
         }
     }

--- a/onnxruntime/src/download.rs
+++ b/onnxruntime/src/download.rs
@@ -46,7 +46,6 @@ impl ModelUrl for AvailableOnnxModel {
 }
 
 impl AvailableOnnxModel {
-    #[cfg(feature = "model-fetching")]
     pub(crate) fn download_to<P>(&self, download_dir: P) -> Result<PathBuf>
     where
         P: AsRef<Path>,

--- a/onnxruntime/src/download/vision.rs
+++ b/onnxruntime/src/download/vision.rs
@@ -1,0 +1,94 @@
+//! Module defining computer vision models available to download.
+
+use super::ModelUrl;
+
+/// Computer vision model
+#[derive(Debug, Clone)]
+pub enum Vision {
+    /// Image classification model
+    ImageClassification(ImageClassificationModel),
+}
+/// Image classification model
+///
+/// > This collection of models take images as input, then classifies the major objects in the images
+/// > into 1000 object categories such as keyboard, mouse, pencil, and many animals.
+///
+/// Source: [https://github.com/onnx/models#image-classification-](https://github.com/onnx/models#image-classification-)
+#[derive(Debug, Clone)]
+pub enum ImageClassificationModel {
+    /// Handwritten digits prediction using CNN
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/mnist](https://github.com/onnx/models/tree/master/vision/classification/mnist)
+    ///
+    /// Variant downloaded: ONNX Version 1.3 with Opset Version 8.
+    Mnist,
+    /// Image classification aimed for mobile targets.
+    ///
+    /// > MobileNet models perform image classification - they take images as input and classify the major
+    /// > object in the image into a set of pre-defined classes. They are trained on ImageNet dataset which
+    /// > contains images from 1000 classes. MobileNet models are also very efficient in terms of speed and
+    /// > size and hence are ideal for embedded and mobile applications.
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/mobilenet](https://github.com/onnx/models/tree/master/vision/classification/mobilenet)
+    ///
+    /// Variant downloaded: ONNX Version 1.2.1 with Opset Version 7.
+    MobileNet,
+    /// A small CNN with AlexNet level accuracy on ImageNet with 50x fewer parameters.
+    ///
+    /// > SqueezeNet is a small CNN which achieves AlexNet level accuracy on ImageNet with 50x fewer parameters.
+    /// > SqueezeNet requires less communication across servers during distributed training, less bandwidth to
+    /// > export a new model from the cloud to an autonomous car and more feasible to deploy on FPGAs and other
+    /// > hardware with limited memory.
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/squeezenet](https://github.com/onnx/models/tree/master/vision/classification/squeezenet)
+    ///
+    /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
+    SqueezeNet,
+    /// Google's Inception
+    Inception(InceptionVersion),
+}
+
+/// Google's Inception
+#[derive(Debug, Clone)]
+pub enum InceptionVersion {
+    /// Google's Inception v1
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v1](https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v1)
+    ///
+    /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
+    V1,
+    /// Google's Inception v2
+    ///
+    /// Source: [https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v2](https://github.com/onnx/models/tree/master/vision/classification/inception_and_googlenet/inception_v2)
+    ///
+    /// Variant downloaded: ONNX Version 1.4 with Opset Version 9.
+    V2,
+}
+
+impl ModelUrl for Vision {
+    fn fetch_url(&self) -> &'static str {
+        match self {
+            Vision::ImageClassification(ic) => ic.fetch_url(),
+        }
+    }
+}
+
+impl ModelUrl for ImageClassificationModel {
+    fn fetch_url(&self) -> &'static str {
+        match self {
+            ImageClassificationModel::Mnist => "https://github.com/onnx/models/raw/master/vision/classification/mnist/model/mnist-8.onnx",
+            ImageClassificationModel::MobileNet => "https://github.com/onnx/models/raw/master/vision/classification/mobilenet/model/mobilenetv2-7.onnx",
+            ImageClassificationModel::SqueezeNet => "https://github.com/onnx/models/raw/master/vision/classification/squeezenet/model/squeezenet1.0-9.onnx",
+            ImageClassificationModel::Inception(version) => version.fetch_url(),
+        }
+    }
+}
+
+impl ModelUrl for InceptionVersion {
+    fn fetch_url(&self) -> &'static str {
+        match self {
+            InceptionVersion::V1 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v1/model/inception-v1-9.onnx",
+            InceptionVersion::V2 => "https://github.com/onnx/models/raw/master/vision/classification/inception_and_googlenet/inception_v2/model/inception-v2-9.onnx",
+        }
+    }
+}

--- a/onnxruntime/src/env.rs
+++ b/onnxruntime/src/env.rs
@@ -16,9 +16,9 @@
 //!
 //! ```no_run
 //! # use std::error::Error;
-//! # use onnxruntime::{env::EnvBuilder, LoggingLevel};
+//! # use onnxruntime::{env::Env, LoggingLevel};
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! let env = EnvBuilder::new()
+//! let env = Env::builder()
 //!     .with_name("test")
 //!     .with_log_level(LoggingLevel::Verbose)
 //!     .build()?;
@@ -87,22 +87,7 @@ pub struct EnvBuilder {
     log_level: LoggingLevel,
 }
 
-impl Default for EnvBuilder {
-    fn default() -> Self {
-        EnvBuilder::new()
-    }
-}
-
 impl EnvBuilder {
-    /// Create a new environment builder using default values
-    /// (name: `default`, log level: [LoggingLevel::Warning](../enum.LoggingLevel.html#variant.Warning))
-    pub fn new() -> EnvBuilder {
-        EnvBuilder {
-            name: "default".into(),
-            log_level: LoggingLevel::Warning,
-        }
-    }
-
     /// Configure the environment with a given name
     ///
     /// **NOTE**: Since ONNX can only define one environment per process,
@@ -188,6 +173,15 @@ pub struct Env {
 }
 
 impl Env {
+    /// Create a new environment builder using default values
+    /// (name: `default`, log level: [LoggingLevel::Warning](../enum.LoggingLevel.html#variant.Warning))
+    pub fn builder() -> EnvBuilder {
+        EnvBuilder {
+            name: "default".into(),
+            log_level: LoggingLevel::Warning,
+        }
+    }
+
     /// Create a new [`SessionBuilder`](../session/struct.SessionBuilder.html)
     /// used to create a new ONNX session.
     pub fn new_session_builder(&self) -> Result<SessionBuilder> {
@@ -201,7 +195,7 @@ mod tests {
 
     #[test]
     fn singleton_env() {
-        let env1 = EnvBuilder::new().with_name("test1").build().unwrap();
+        let env1 = Env::builder().with_name("test1").build().unwrap();
 
         assert_eq!(
             G_NAMED_ENV.lock().unwrap().name,
@@ -216,7 +210,7 @@ mod tests {
             *env1.inner.lock().unwrap().env_ptr.0.get_mut() as usize
         );
 
-        let env2 = EnvBuilder::new().with_name("test2").build().unwrap();
+        let env2 = Env::builder().with_name("test2").build().unwrap();
 
         assert_eq!(
             G_NAMED_ENV.lock().unwrap().name,
@@ -229,7 +223,7 @@ mod tests {
             "Environment should contain information from first creation"
         );
 
-        let env3 = EnvBuilder::new().with_name("test3").build().unwrap();
+        let env3 = Env::builder().with_name("test3").build().unwrap();
 
         assert_eq!(
             G_NAMED_ENV.lock().unwrap().name,

--- a/onnxruntime/src/error.rs
+++ b/onnxruntime/src/error.rs
@@ -1,6 +1,6 @@
 //! Module containing error definitions.
 
-use std::path::PathBuf;
+use std::{io, path::PathBuf};
 
 use thiserror::Error;
 
@@ -68,6 +68,10 @@ pub enum OrtError {
     #[error("Failed to get tensor data: {0}")]
     GetTensorMutableData(OrtApiError),
 
+    /// Error occurred when downloading a pre-trained ONNX model from the [ONNX Model Zoo](https://github.com/onnx/models)
+    #[error("Failed to download ONNX model: {0}")]
+    DownloadError(#[from] OrtDownloadError),
+
     /// Dimensions of input data and ONNX model loaded from file do not match
     #[error("Dimensions do not match: {input:?} for the input but model expects {model:?}")]
     NonMatchingDimensions {
@@ -102,6 +106,25 @@ pub enum OrtApiError {
     /// Details as reported by the ONNX C API in case of error cannot be converted to UTF-8
     #[error("Error calling ONNX Runtime C function and failed to convert error message to UTF-8")]
     IntoStringError(std::ffi::IntoStringError),
+}
+
+/// Error from downloading pre-trained model from the [ONNX Model Zoo](https://github.com/onnx/models).
+#[derive(Error, Debug)]
+pub enum OrtDownloadError {
+    /// Generic input/output error
+    #[error("Error downloading data to file: {0}")]
+    IoError(#[from] io::Error),
+    /// Error getting content-length from an HTTP GET request
+    #[error("Error getting content-length")]
+    ContentLengthError,
+    /// Mismatch between amount of downloaded and expected bytes
+    #[error("Error copying data to file: expected {expected} length, received {io}")]
+    CopyError {
+        /// Expected amount of bytes to download
+        expected: u64,
+        /// Number of bytes read from network and written to file
+        io: u64,
+    },
 }
 
 /// Wrapper type around a ONNX C API's `OrtStatus` pointer

--- a/onnxruntime/src/lib.rs
+++ b/onnxruntime/src/lib.rs
@@ -91,6 +91,7 @@ use lazy_static::lazy_static;
 
 use onnxruntime_sys as sys;
 
+pub mod download;
 pub mod env;
 pub mod error;
 mod memory;

--- a/onnxruntime/src/lib.rs
+++ b/onnxruntime/src/lib.rs
@@ -91,6 +91,7 @@ use lazy_static::lazy_static;
 
 use onnxruntime_sys as sys;
 
+#[cfg(feature = "model-fetching")]
 pub mod download;
 pub mod env;
 pub mod error;

--- a/onnxruntime/src/lib.rs
+++ b/onnxruntime/src/lib.rs
@@ -27,9 +27,9 @@
 //!
 //! ```no_run
 //! # use std::error::Error;
-//! # use onnxruntime::{env::EnvBuilder, LoggingLevel};
+//! # use onnxruntime::{env::Env, LoggingLevel};
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! let env = EnvBuilder::new()
+//! let env = Env::builder()
 //!     .with_name("test")
 //!     .with_log_level(LoggingLevel::Verbose)
 //!     .build()?;
@@ -41,9 +41,9 @@
 //!
 //! ```no_run
 //! # use std::error::Error;
-//! # use onnxruntime::{env::EnvBuilder, LoggingLevel, GraphOptimizationLevel};
+//! # use onnxruntime::{env::Env, LoggingLevel, GraphOptimizationLevel};
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! # let env = EnvBuilder::new()
+//! # let env = Env::builder()
 //! #     .with_name("test")
 //! #     .with_log_level(LoggingLevel::Verbose)
 //! #     .build()?;
@@ -60,9 +60,9 @@
 //!
 //! ```no_run
 //! # use std::error::Error;
-//! # use onnxruntime::{env::EnvBuilder, LoggingLevel, GraphOptimizationLevel, tensor::TensorFromOrt};
+//! # use onnxruntime::{env::Env, LoggingLevel, GraphOptimizationLevel, tensor::TensorFromOrt};
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! # let env = EnvBuilder::new()
+//! # let env = Env::builder()
 //! #     .with_name("test")
 //! #     .with_log_level(LoggingLevel::Verbose)
 //! #     .build()?;
@@ -98,7 +98,6 @@ pub mod session;
 pub mod tensor;
 
 // Re-export
-pub use env::EnvBuilder;
 pub use error::{OrtApiError, OrtError, Result};
 
 lazy_static! {

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -23,6 +23,7 @@ use crate::{
     TypeToTensorElementDataType,
 };
 
+#[cfg(feature = "model-fetching")]
 use crate::{download::AvailableOnnxModel, error::OrtDownloadError};
 
 /// Type used to create a session using the _builder pattern_
@@ -131,6 +132,7 @@ impl SessionBuilder {
     }
 
     /// Download an ONNX pre-trained model from the [ONNX Model Zoo](https://github.com/onnx/models) and commit the session
+    #[cfg(feature = "model-fetching")]
     pub fn with_downloaded_model<M>(self, model: M) -> Result<Session>
     where
         M: Into<AvailableOnnxModel>,

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -1,12 +1,14 @@
 //! Module containing session types
 
 use std::{
-    env,
     ffi::CString,
     fmt::Debug,
     path::Path,
     sync::{Arc, Mutex},
 };
+
+#[cfg(feature = "model-fetching")]
+use std::env;
 
 use ndarray::Array;
 

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -1,6 +1,7 @@
 //! Module containing session types
 
 use std::{
+    env,
     ffi::CString,
     fmt::Debug,
     path::Path,
@@ -21,6 +22,8 @@ use crate::{
     AllocatorType, GraphOptimizationLevel, MemType, TensorElementDataType,
     TypeToTensorElementDataType,
 };
+
+use crate::{download::AvailableOnnxModel, error::OrtDownloadError};
 
 /// Type used to create a session using the _builder pattern_
 ///
@@ -125,6 +128,13 @@ impl SessionBuilder {
     pub fn with_memory_type(mut self, memory_type: MemType) -> Result<SessionBuilder> {
         self.memory_type = memory_type;
         Ok(self)
+    }
+
+    /// Download an ONNX pre-trained model from the [ONNX Model Zoo](https://github.com/onnx/models) and commit the session
+    pub fn with_downloaded_model(self, model: AvailableOnnxModel) -> Result<Session> {
+        let download_dir = env::current_dir().map_err(OrtDownloadError::IoError)?;
+        let downloaded_path = model.download_to(download_dir)?;
+        self.load_model_from_file_monorphomized(downloaded_path.as_ref())
     }
 
     // TODO: Add all functions changing the options.

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -37,9 +37,9 @@ use crate::{
 ///
 /// ```no_run
 /// # use std::error::Error;
-/// # use onnxruntime::{env::EnvBuilder, LoggingLevel, GraphOptimizationLevel};
+/// # use onnxruntime::{env::Env, LoggingLevel, GraphOptimizationLevel};
 /// # fn main() -> Result<(), Box<dyn Error>> {
-/// let env = EnvBuilder::new()
+/// let env = Env::builder()
 ///     .with_name("test")
 ///     .with_log_level(LoggingLevel::Verbose)
 ///     .build()?;

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -131,9 +131,12 @@ impl SessionBuilder {
     }
 
     /// Download an ONNX pre-trained model from the [ONNX Model Zoo](https://github.com/onnx/models) and commit the session
-    pub fn with_downloaded_model(self, model: AvailableOnnxModel) -> Result<Session> {
+    pub fn with_downloaded_model<M>(self, model: M) -> Result<Session>
+    where
+        M: Into<AvailableOnnxModel>,
+    {
         let download_dir = env::current_dir().map_err(OrtDownloadError::IoError)?;
-        let downloaded_path = model.download_to(download_dir)?;
+        let downloaded_path = model.into().download_to(download_dir)?;
         self.load_model_from_file_monorphomized(downloaded_path.as_ref())
     }
 


### PR DESCRIPTION
Add a cargo feature to automatically download pre-trained model from ONNX Zoo.

HTTP Get is done using `ureq`, which is small but sync. This _will_ block the thread until the whole model file is streamed to disk. Those models can be quite large.