### PR TITLE
Custom logger for onnx runtime

### DIFF
--- a/onnxruntime/examples/sample.rs
+++ b/onnxruntime/examples/sample.rs
@@ -6,6 +6,8 @@ use onnxruntime::{
     download::vision::ImageClassification, environment::Environment, GraphOptimizationLevel,
     LoggingLevel,
 };
+use tracing::Level;
+use tracing_subscriber::FmtSubscriber;
 
 type Error = Box<dyn std::error::Error>;
 
@@ -17,9 +19,18 @@ fn main() {
 }
 
 fn run() -> Result<(), Error> {
+    // Setup the example's log level.
+    // NOTE: ONNX Runtime's log level is controlled separately when building the environment.
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::DEBUG)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
     let environment = Environment::builder()
         .with_name("test")
-        .with_log_level(LoggingLevel::Verbose)
+        // The ONNX Runtime's log level can be different than the one of the wrapper crate or the application.
+        .with_log_level(LoggingLevel::Warning)
         .build()?;
 
     let mut session = environment

--- a/onnxruntime/examples/sample.rs
+++ b/onnxruntime/examples/sample.rs
@@ -22,7 +22,7 @@ fn run() -> Result<(), Error> {
     // Setup the example's log level.
     // NOTE: ONNX Runtime's log level is controlled separately when building the environment.
     let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::DEBUG)
+        .with_max_level(Level::TRACE)
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
@@ -30,7 +30,7 @@ fn run() -> Result<(), Error> {
     let environment = Environment::builder()
         .with_name("test")
         // The ONNX Runtime's log level can be different than the one of the wrapper crate or the application.
-        .with_log_level(LoggingLevel::Warning)
+        .with_log_level(LoggingLevel::Info)
         .build()?;
 
     let mut session = environment

--- a/onnxruntime/src/lib.rs
+++ b/onnxruntime/src/lib.rs
@@ -168,6 +168,95 @@ fn char_p_to_string(raw: *const i8) -> Result<String> {
     .map_err(OrtError::StringConversion)
 }
 
+mod onnxruntime {
+    //! Module containing a custom logger, used to catch the runtime's own logging and send it
+    //! to Rust's tracing logging instead.
+
+    use std::ffi::CStr;
+    use tracing::{debug, error, info, span, trace, warn, Level};
+
+    /// Runtime's logging sends the code location where the log happened, will be parsed to this struct.
+    #[derive(Debug)]
+    struct CodeLocation<'a> {
+        file: &'a str,
+        line_number: &'a str,
+        function: &'a str,
+    }
+
+    impl<'a> From<&'a str> for CodeLocation<'a> {
+        fn from(code_location: &'a str) -> Self {
+            let mut splitter = code_location.split(' ');
+            let file_and_line_number = splitter.next().unwrap_or("<unknown file:line>");
+            let function = splitter.next().unwrap_or("<unknown module>");
+            let mut file_and_line_number_splitter = file_and_line_number.split(':');
+            let file = file_and_line_number_splitter
+                .next()
+                .unwrap_or("<unknown file>");
+            let line_number = file_and_line_number_splitter
+                .next()
+                .unwrap_or("<unknown line number>");
+
+            CodeLocation {
+                file,
+                line_number,
+                function,
+            }
+        }
+    }
+
+    /// Callback from C that will handle the logging, forwarding the runtime's logs to the tracing crate.
+    pub(crate) extern "C" fn custom_logger(
+        _params: *mut std::ffi::c_void,
+        severity: u32,
+        category: *const i8,
+        logid: *const i8,
+        code_location: *const i8,
+        message: *const i8,
+    ) {
+        let log_level = match severity {
+            0 => Level::TRACE,
+            1 => Level::DEBUG,
+            2 => Level::INFO,
+            3 => Level::WARN,
+            _ => Level::ERROR,
+        };
+
+        assert_ne!(category, std::ptr::null());
+        let category = unsafe { CStr::from_ptr(category) };
+        assert_ne!(code_location, std::ptr::null());
+        let code_location = unsafe { CStr::from_ptr(code_location) }
+            .to_str()
+            .unwrap_or("unknown");
+        assert_ne!(message, std::ptr::null());
+        let message = unsafe { CStr::from_ptr(message) };
+
+        assert_ne!(logid, std::ptr::null());
+        let logid = unsafe { CStr::from_ptr(logid) };
+
+        // Parse the code location
+        let code_location: CodeLocation = code_location.into();
+
+        let span = span!(
+            Level::TRACE,
+            "onnxruntime",
+            category = category.to_str().unwrap_or("<unknown>"),
+            file = code_location.file,
+            line_number = code_location.line_number,
+            function = code_location.function,
+            logid = logid.to_str().unwrap_or("<unknown>"),
+        );
+        let _enter = span.enter();
+
+        match log_level {
+            Level::TRACE => trace!("{:?}", message),
+            Level::DEBUG => debug!("{:?}", message),
+            Level::INFO => info!("{:?}", message),
+            Level::WARN => warn!("{:?}", message),
+            Level::ERROR => error!("{:?}", message),
+        }
+    }
+}
+
 /// Logging level of the ONNX Runtime C API
 #[derive(Debug)]
 #[repr(u32)]


### PR DESCRIPTION
Use `CreateEnvWithCustomLogger()` instead of `CreateEnv()` when creating environment as to pass a custom logger.

This allows logging on the Rust side through the `tracing` crate.

NOTE: The `logid` is initially empty even though I was expecting it to _always_ contain the environment name (`Environment::builder().with_name("test")`). At some point it starts to contain the proper environment name. Maybe a bug in the runtime?

For example:
```
[...]
Aug 26 21:56:29.624 DEBUG onnxruntime{category="onnxruntime" file="sequential_executor.cc" line_number="150" function="Execute" logid=""}: onnxruntime::onnxruntime: "Begin execution"
Aug 26 21:56:29.625 DEBUG onnxruntime{category="onnxruntime" file="bfc_arena.cc" line_number="263" function="AllocateRawInternal" logid="test"}: onnxruntime::onnxruntime: "Extending BFCArena for Cpu. bin_num:13 rounded_bytes:3154176"
[...]
```