### PR TITLE
Bump ureq to 1.5.1

### DIFF
--- a/onnxruntime-sys/Cargo.toml
+++ b/onnxruntime-sys/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["neuralnetworks", "onnx", "bindings"]
 
 [build-dependencies]
 bindgen = "0.55"
-ureq = "1.4"
+ureq = "1.5.1"
 
 [target.'cfg(windows)'.build-dependencies]
 zip = "0.5"


### PR DESCRIPTION
<=1.5.0 fails to download pre-built archive.

See: https://github.com/algesten/ureq/issues/179