### PR TITLE
Runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 onnxruntime.git
 Cargo.lock
 **/synset.txt
+.idea/

--- a/onnxruntime/src/error.rs
+++ b/onnxruntime/src/error.rs
@@ -4,6 +4,7 @@ use std::{io, path::PathBuf};
 
 use thiserror::Error;
 
+use ndarray::ShapeError;
 use onnxruntime_sys as sys;
 
 use crate::{char_p_to_string, g_ort};
@@ -91,6 +92,9 @@ pub enum OrtError {
     /// Attempt to build a Rust `CString` from a null pointer
     #[error("Failed to build CString when original contains null: {0}")]
     CStringNulError(#[from] std::ffi::NulError),
+    /// Output dimensionality mismatch
+    #[error("Output dimensionality mismatch: {0}")]
+    OutputDimensionalityMismatch(#[from] ShapeError),
 }
 
 /// Error used when dimensions of input (from model and from inference call)

--- a/onnxruntime/src/lib.rs
+++ b/onnxruntime/src/lib.rs
@@ -125,6 +125,7 @@ pub mod download;
 pub mod environment;
 pub mod error;
 mod memory;
+pub mod runner;
 pub mod session;
 pub mod tensor;
 

--- a/onnxruntime/src/runner.rs
+++ b/onnxruntime/src/runner.rs
@@ -1,0 +1,231 @@
+use std::ffi::CString;
+use std::fmt::Debug;
+use std::ops::{Index, IndexMut};
+
+use ndarray::{Array, Dimension, IxDyn};
+
+use onnxruntime_sys as sys;
+
+use crate::error::{status_to_result, OrtError};
+use crate::memory::MemoryInfo;
+use crate::session::{Output, Session};
+use crate::tensor::OrtTensor;
+use crate::{g_ort, Result, TypeToTensorElementDataType};
+
+pub trait Element: 'static + Clone + Debug + TypeToTensorElementDataType + Default {}
+
+impl<T: 'static + Clone + Debug + TypeToTensorElementDataType + Default> Element for T {}
+
+fn names_to_ptrs(names: impl Iterator<Item = String>) -> Vec<*const i8> {
+    names
+        .map(|name| CString::new(name.clone()).unwrap().into_raw() as *const _)
+        .collect()
+}
+
+fn compute_output_shapes<TIn, DIn: Dimension>(
+    input_arrays: &[Array<TIn, DIn>],
+    outputs: &[Output],
+) -> Vec<Vec<usize>> {
+    outputs
+        .iter()
+        .enumerate()
+        .map(|(idx, output)| {
+            output
+                .dimensions
+                .iter()
+                .enumerate()
+                .map(|(jdx, dim)| match dim {
+                    None => input_arrays[idx].shape()[jdx],
+                    Some(d) => *d as usize,
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn arrays_to_tensors<T: Element, D: Dimension>(
+    memory_info: &MemoryInfo,
+    arrays: impl IntoIterator<Item = Array<T, D>>,
+) -> Result<Vec<OrtTensor<T, D>>> {
+    Ok(arrays
+        .into_iter()
+        .map(|arr| OrtTensor::from_array(memory_info, arr))
+        .collect::<Result<Vec<_>>>()?)
+}
+
+fn tensors_to_ptr<'a, 's: 'a, T: Element, D: Dimension + 'a>(
+    tensors: impl IntoIterator<Item = &'a OrtTensor<'s, T, D>>,
+) -> Vec<*const sys::OrtValue> {
+    tensors
+        .into_iter()
+        .map(|tensor| tensor.c_ptr as *const _)
+        .collect()
+}
+
+fn tensors_to_mut_ptr<'a, 's: 'a, T: Element, D: Dimension + 'a>(
+    tensors: impl IntoIterator<Item = &'a mut OrtTensor<'s, T, D>>,
+) -> Vec<*mut sys::OrtValue> {
+    tensors
+        .into_iter()
+        .map(|tensor| tensor.c_ptr as *mut _)
+        .collect()
+}
+
+fn arrays_to_ort<T: Element, D: Dimension>(
+    memory_info: &MemoryInfo,
+    arrays: impl IntoIterator<Item = Array<T, D>>,
+) -> Result<(Vec<OrtTensor<T, D>>, Vec<*const sys::OrtValue>)> {
+    let ort_tensors = arrays
+        .into_iter()
+        .map(|arr| OrtTensor::from_array(memory_info, arr))
+        .collect::<Result<Vec<_>>>()?;
+    let ort_values = ort_tensors
+        .iter()
+        .map(|tensor| tensor.c_ptr as *const _)
+        .collect();
+    Ok((ort_tensors, ort_values))
+}
+
+fn arrays_with_shapes<T: Element, D: Dimension>(shapes: &[Vec<usize>]) -> Result<Vec<Array<T, D>>> {
+    Ok(shapes
+        .into_iter()
+        .map(|shape| Array::<_, IxDyn>::default(shape.clone()).into_dimensionality())
+        .collect::<std::result::Result<Vec<Array<T, D>>, _>>()?)
+}
+
+pub struct Inputs<'r, 'a, T: Element, D: Dimension> {
+    tensors: &'a mut [OrtTensor<'r, T, D>],
+}
+
+impl<T: Element, D: Dimension> Inputs<'_, '_, T, D> {}
+
+impl<T: Element, D: Dimension> Index<usize> for Inputs<'_, '_, T, D> {
+    type Output = Array<T, D>;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &(*self.tensors[index])
+    }
+}
+
+impl<T: Element, D: Dimension> IndexMut<usize> for Inputs<'_, '_, T, D> {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut (*self.tensors[index])
+    }
+}
+
+pub struct Outputs<'r, 'a, T: Element, D: Dimension> {
+    tensors: &'a [OrtTensor<'r, T, D>],
+}
+
+impl<T: Element, D: Dimension> Outputs<'_, '_, T, D> {}
+
+impl<T: Element, D: Dimension> Index<usize> for Outputs<'_, '_, T, D> {
+    type Output = Array<T, D>;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &(*self.tensors[index])
+    }
+}
+
+pub struct RunnerBuilder<'s, TIn: Element, DIn: Dimension> {
+    session: &'s Session,
+    input_arrays: Vec<Array<TIn, DIn>>,
+}
+
+impl<'s, TIn: Element, DIn: Dimension> RunnerBuilder<'s, TIn, DIn> {
+    #[inline]
+    pub fn new(
+        session: &'s Session,
+        input_arrays: impl IntoIterator<Item = Array<TIn, DIn>>,
+    ) -> Self {
+        Self {
+            session,
+            input_arrays: input_arrays.into_iter().collect(),
+        }
+    }
+
+    #[inline]
+    pub fn with_output<TOut: Element, DOut: Dimension>(
+        self,
+    ) -> Result<Runner<'s, TIn, DIn, TOut, DOut>> {
+        Runner::new(self.session, self.input_arrays)
+    }
+
+    #[inline]
+    pub fn with_output_dyn<TOut: Element>(self) -> Result<Runner<'s, TIn, DIn, TOut, IxDyn>> {
+        Runner::new(self.session, self.input_arrays)
+    }
+}
+
+pub struct Runner<'s, TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension> {
+    session: &'s Session,
+    input_names_ptr: Vec<*const i8>,
+    output_names_ptr: Vec<*const i8>,
+    input_ort_tensors: Vec<OrtTensor<'s, TIn, DIn>>,
+    input_ort_values_ptr: Vec<*const sys::OrtValue>,
+    output_ort_tensors: Vec<OrtTensor<'s, TOut, DOut>>,
+    output_ort_values_ptr: Vec<*mut sys::OrtValue>,
+}
+
+impl<'s, TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension>
+    Runner<'s, TIn, DIn, TOut, DOut>
+{
+    pub fn new(
+        session: &'s Session,
+        input_arrays: impl IntoIterator<Item = Array<TIn, DIn>>,
+    ) -> Result<Self> {
+        let input_names_ptr = names_to_ptrs(session.inputs.iter().map(|i| i.name.clone()));
+        let output_names_ptr = names_to_ptrs(session.outputs.iter().map(|o| o.name.clone()));
+        let input_arrays = input_arrays.into_iter().collect::<Vec<_>>();
+        session.validate_input_shapes(&input_arrays)?;
+        let output_shapes = compute_output_shapes(&input_arrays, &session.outputs);
+        let output_arrays = arrays_with_shapes::<_, DOut>(&output_shapes)?;
+        let input_ort_tensors = arrays_to_tensors(&session.memory_info, input_arrays)?;
+        let input_ort_values_ptr = tensors_to_ptr(&input_ort_tensors);
+        let mut output_ort_tensors = arrays_to_tensors(&session.memory_info, output_arrays)?;
+        let output_ort_values_ptr = tensors_to_mut_ptr(&mut output_ort_tensors);
+        Ok(Self {
+            session,
+            input_names_ptr,
+            output_names_ptr,
+            input_ort_tensors,
+            input_ort_values_ptr,
+            output_ort_tensors,
+            output_ort_values_ptr,
+        })
+    }
+
+    #[inline]
+    pub fn inputs(&mut self) -> Inputs<'s, '_, TIn, DIn> {
+        Inputs {
+            tensors: self.input_ort_tensors.as_mut_slice(),
+        }
+    }
+
+    #[inline]
+    pub fn outputs(&'s self) -> Outputs<'s, '_, TOut, DOut> {
+        Outputs {
+            tensors: self.output_ort_tensors.as_slice(),
+        }
+    }
+
+    #[inline]
+    pub fn execute(&mut self) -> Result<()> {
+        Ok(status_to_result(unsafe {
+            g_ort().Run.unwrap()(
+                self.session.session_ptr,
+                std::ptr::null() as _,
+                self.input_names_ptr.as_ptr(),
+                self.input_ort_values_ptr.as_ptr(),
+                self.input_ort_values_ptr.len() as _,
+                self.output_names_ptr.as_ptr(),
+                self.output_names_ptr.len() as _,
+                self.output_ort_values_ptr.as_mut_ptr(),
+            )
+        })
+        .map_err(OrtError::Run)?)
+    }
+}

--- a/onnxruntime/src/runner.rs
+++ b/onnxruntime/src/runner.rs
@@ -229,3 +229,16 @@ impl<'s, TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension>
         .map_err(OrtError::Run)?)
     }
 }
+
+impl<TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension> Drop
+    for Runner<'_, TIn, DIn, TOut, DOut>
+{
+    fn drop(&mut self) {
+        for ptr in &self.input_names_ptr {
+            let _s = unsafe { CString::from_raw(*ptr as _) };
+        }
+        for ptr in &self.output_names_ptr {
+            let _s = unsafe { CString::from_raw(*ptr as _) };
+        }
+    }
+}

--- a/onnxruntime/src/runner.rs
+++ b/onnxruntime/src/runner.rs
@@ -130,15 +130,15 @@ impl<T: Element, D: Dimension> Index<usize> for Outputs<'_, '_, T, D> {
     }
 }
 
-pub struct RunnerBuilder<'s, TIn: Element, DIn: Dimension> {
-    session: &'s Session,
+pub struct RunnerBuilder<'s, 'a, TIn: Element, DIn: Dimension> {
+    session: &'s Session<'a>,
     input_arrays: Vec<Array<TIn, DIn>>,
 }
 
-impl<'s, TIn: Element, DIn: Dimension> RunnerBuilder<'s, TIn, DIn> {
+impl<'s, 'a, TIn: Element, DIn: Dimension> RunnerBuilder<'s, 'a, TIn, DIn> {
     #[inline]
     pub fn new(
-        session: &'s Session,
+        session: &'s Session<'a>,
         input_arrays: impl IntoIterator<Item = Array<TIn, DIn>>,
     ) -> Self {
         Self {
@@ -150,18 +150,18 @@ impl<'s, TIn: Element, DIn: Dimension> RunnerBuilder<'s, TIn, DIn> {
     #[inline]
     pub fn with_output<TOut: Element, DOut: Dimension>(
         self,
-    ) -> Result<Runner<'s, TIn, DIn, TOut, DOut>> {
+    ) -> Result<Runner<'s, 'a, TIn, DIn, TOut, DOut>> {
         Runner::new(self.session, self.input_arrays)
     }
 
     #[inline]
-    pub fn with_output_dyn<TOut: Element>(self) -> Result<Runner<'s, TIn, DIn, TOut, IxDyn>> {
+    pub fn with_output_dyn<TOut: Element>(self) -> Result<Runner<'s, 'a, TIn, DIn, TOut, IxDyn>> {
         Runner::new(self.session, self.input_arrays)
     }
 }
 
-pub struct Runner<'s, TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension> {
-    session: &'s Session,
+pub struct Runner<'s, 'a, TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension> {
+    session: &'s Session<'a>,
     input_names_ptr: Vec<*const i8>,
     output_names_ptr: Vec<*const i8>,
     input_ort_tensors: Vec<OrtTensor<'s, TIn, DIn>>,
@@ -170,11 +170,11 @@ pub struct Runner<'s, TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimensi
     output_ort_values_ptr: Vec<*mut sys::OrtValue>,
 }
 
-impl<'s, TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension>
-    Runner<'s, TIn, DIn, TOut, DOut>
+impl<'s, 'a, TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension>
+    Runner<'s, 'a, TIn, DIn, TOut, DOut>
 {
     pub fn new(
-        session: &'s Session,
+        session: &'s Session<'a>,
         input_arrays: impl IntoIterator<Item = Array<TIn, DIn>>,
     ) -> Result<Self> {
         let input_names_ptr = names_to_ptrs(session.inputs.iter().map(|i| i.name.clone()));
@@ -231,7 +231,7 @@ impl<'s, TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension>
 }
 
 impl<TIn: Element, DIn: Dimension, TOut: Element, DOut: Dimension> Drop
-    for Runner<'_, TIn, DIn, TOut, DOut>
+    for Runner<'_, '_, TIn, DIn, TOut, DOut>
 {
     fn drop(&mut self) {
         for ptr in &self.input_names_ptr {

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -291,9 +291,9 @@ impl SessionBuilder {
 /// Type storing the session information, built from an [`Environment`](environment/struct.Environment.html)
 #[derive(Debug)]
 pub struct Session {
-    session_ptr: *mut sys::OrtSession,
+    pub(crate) session_ptr: *mut sys::OrtSession,
     allocator_ptr: *mut sys::OrtAllocator,
-    memory_info: MemoryInfo,
+    pub(crate) memory_info: MemoryInfo,
     /// Information about the ONNX's inputs as stored in loaded file
     pub inputs: Vec<Input>,
     /// Information about the ONNX's outputs as stored in loaded file

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -365,7 +365,7 @@ impl<'a> Session<'a> {
     pub fn make_runner<T: Element, D: Dimension, I: IntoIterator<Item = Array<T, D>>>(
         &self,
         input_arrays: I,
-    ) -> RunnerBuilder<'_, T, D> {
+    ) -> RunnerBuilder<'_, 'a, T, D> {
         RunnerBuilder::new(self, input_arrays)
     }
 

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -487,7 +487,7 @@ impl Session {
     //     Tensor::from_array(self, array)
     // }
 
-    fn validate_input_shapes<TIn, D>(&mut self, input_arrays: &[Array<TIn, D>]) -> Result<()>
+    pub(crate) fn validate_input_shapes<TIn, D>(&self, input_arrays: &[Array<TIn, D>]) -> Result<()>
     where
         TIn: TypeToTensorElementDataType + Debug + Clone,
         D: ndarray::Dimension,

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -10,7 +10,7 @@ use std::os::windows::ffi::OsStrExt;
 #[cfg(feature = "model-fetching")]
 use std::env;
 
-use ndarray::Array;
+use ndarray::{Array, Dimension};
 use tracing::{debug, error};
 
 use onnxruntime_sys as sys;
@@ -21,6 +21,7 @@ use crate::{
     error::{status_to_result, NonMatchingDimensionsError, OrtError, Result},
     g_ort,
     memory::MemoryInfo,
+    runner::{Element, RunnerBuilder},
     tensor::{
         ort_owned_tensor::{OrtOwnedTensor, OrtOwnedTensorExtractor},
         OrtTensor,
@@ -361,6 +362,13 @@ impl Drop for Session {
 }
 
 impl Session {
+    pub fn make_runner<T: Element, D: Dimension, I: IntoIterator<Item = Array<T, D>>>(
+        &self,
+        input_arrays: I,
+    ) -> RunnerBuilder<'_, T, D> {
+        RunnerBuilder::new(self, input_arrays)
+    }
+
     /// Run the input data through the ONNX graph, performing inference.
     ///
     /// Note that ONNX models can have multiple inputs; a `Vec<_>` is thus

--- a/onnxruntime/src/tensor/ort_owned_tensor.rs
+++ b/onnxruntime/src/tensor/ort_owned_tensor.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Debug, ops::Deref};
 
 use ndarray::{Array, ArrayView};
-use tracing::debug;
+use tracing::trace;
 
 use onnxruntime_sys as sys;
 
@@ -124,9 +124,9 @@ where
     D: ndarray::Dimension,
     'm: 't, // 'm outlives 't
 {
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     fn drop(&mut self) {
-        debug!("Dropping OrtOwnedTensor.");
+        trace!("Dropping OrtOwnedTensor.");
         unsafe { g_ort().ReleaseValue.unwrap()(self.tensor_ptr) }
 
         self.tensor_ptr = std::ptr::null_mut();

--- a/onnxruntime/src/tensor/ort_tensor.rs
+++ b/onnxruntime/src/tensor/ort_tensor.rs
@@ -1,6 +1,6 @@
 //! Module containing tensor with memory owned by Rust
 
-use std::{fmt::Debug, ops::Deref};
+use std::{fmt::Debug, ops::Deref, ops::DerefMut};
 
 use ndarray::Array;
 use tracing::{error, trace};
@@ -87,6 +87,16 @@ where
 
     fn deref(&self) -> &Self::Target {
         &self.array
+    }
+}
+
+impl<'t, T, D> DerefMut for OrtTensor<'t, T, D>
+where
+    T: TypeToTensorElementDataType + Debug + Clone,
+    D: ndarray::Dimension,
+{
+    fn deref_mut(&mut self) -> &mut <Self as Deref>::Target {
+        &mut self.array
     }
 }
 

--- a/onnxruntime/src/tensor/ort_tensor.rs
+++ b/onnxruntime/src/tensor/ort_tensor.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Debug, ops::Deref};
 
 use ndarray::Array;
-use tracing::{debug, error};
+use tracing::{error, trace};
 
 use onnxruntime_sys as sys;
 
@@ -95,10 +95,10 @@ where
     T: TypeToTensorElementDataType + Debug + Clone,
     D: ndarray::Dimension,
 {
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     fn drop(&mut self) {
         // We need to let the C part free
-        debug!("Dropping Tensor.");
+        trace!("Dropping Tensor.");
         if self.c_ptr.is_null() {
             error!("Null pointer, not calling free.");
         } else {


### PR DESCRIPTION
@nbigaouette This is somewhat WIP in that if this is deemed acceptable, then some docs should be added, things may be cleaned up a bit etc, but it's fully functional. Basically I wanted to push this asap to see what you think.

- On tiny examples it reduces the total runtime from 15us to 8us.  Pretty much 100% of that time is now being spent within ONNX C API.
- For big examples, I think this would be handy as well since it allows to avoid *both* copying the inputs and avoids allocations for the outputs.
- There's no more tracing calls on the hot path (since there's no drops).
- There's `Default` currently required for output type. As long as we're sure we'll never use strings, might add a `Copy` to the element type requirements and then `Default` can be dropped (so that the output array can be zero-initialized).

Can be used like this:

```rust
let mut runner = session.make_runner(input_arrays).with_output::<f32, Ix3>()?;
runner.execute()?; // no allocations to generate outputs, no copying of inputs
dbg!(&runner.outputs()[0]);
*(&mut runner.inputs()[0]) *= 2.0f32; // modify the inputs without copying or allocation
runner.execute()?; // no allocations, no copying
dbg!(&runner.outputs()[0]);
```