### PR TITLE
Re-export ndarray

### DIFF
--- a/onnxruntime/examples/sample.rs
+++ b/onnxruntime/examples/sample.rs
@@ -1,9 +1,8 @@
 #![forbid(unsafe_code)]
 
-use ndarray::Array;
-
 use onnxruntime::{
-    environment::Environment, tensor::OrtOwnedTensor, GraphOptimizationLevel, LoggingLevel,
+    environment::Environment, ndarray::Array, tensor::OrtOwnedTensor, GraphOptimizationLevel,
+    LoggingLevel,
 };
 use tracing::Level;
 use tracing_subscriber::FmtSubscriber;

--- a/onnxruntime/src/lib.rs
+++ b/onnxruntime/src/lib.rs
@@ -132,6 +132,9 @@ pub mod tensor;
 pub use error::{OrtApiError, OrtError, Result};
 use sys::OnnxEnumInt;
 
+// Re-export ndarray as it's part of the public API anyway
+pub use ndarray;
+
 lazy_static! {
     // static ref G_ORT: Arc<Mutex<AtomicPtr<sys::OrtApi>>> =
     //     Arc::new(Mutex::new(AtomicPtr::new(unsafe {


### PR DESCRIPTION
Since the public API depends on `ndarray`, downstream user need to add it in their `Cargo.toml`.

This re-export allows downstream user _not_ to add the dependency in their `Cargo.toml`.

Closes #44.