### PR TITLE
expand api error msg

### DIFF
--- a/onnxruntime/src/error.rs
+++ b/onnxruntime/src/error.rs
@@ -117,7 +117,7 @@ pub enum NonMatchingDimensionsError {
 #[derive(Error, Debug)]
 pub enum OrtApiError {
     /// Details as reported by the ONNX C API in case of error
-    #[error("Error calling ONNX Runtime C function")]
+    #[error("Error calling ONNX Runtime C function: {0}")]
     Msg(String),
     /// Details as reported by the ONNX C API in case of error cannot be converted to UTF-8
     #[error("Error calling ONNX Runtime C function and failed to convert error message to UTF-8")]


### PR DESCRIPTION
Previously this error message would read for example like:

> Failed to create session: Error calling ONNX Runtime C function

This is pretty useless.

Now it reads for example like:

> Failed to create session: Error calling ONNX Runtime C function: Could not find an implementation for the node StatefulPartitionedCall/yolo_v3/non_max_suppression_padded/PartitionedCall/TopKV2:TopK(11)

Which is much more informative and actionable. :)