### PR TITLE
Add String data type support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 onnxruntime.git
 Cargo.lock
 **/synset.txt
+
+/.idea

--- a/onnxruntime-sys/build.rs
+++ b/onnxruntime-sys/build.rs
@@ -105,7 +105,10 @@ fn generate_bindings(include_dir: &Path) {
         .expect("Couldn't write bindings!");
 }
 
-fn download<P: AsRef<Path>>(source_url: &str, target_file: P) {
+fn download<P>(source_url: &str, target_file: P)
+where
+    P: AsRef<Path>,
+{
     let resp = ureq::get(source_url)
         .timeout_connect(1_000) // 1 second
         .timeout(std::time::Duration::from_secs(300))

--- a/onnxruntime/examples/print_structure.rs
+++ b/onnxruntime/examples/print_structure.rs
@@ -1,0 +1,39 @@
+//! Display the input and output structure of an ONNX model.
+use onnxruntime::environment;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // provide path to .onnx model on disk
+    let path = std::env::args()
+        .skip(1)
+        .next()
+        .expect("Must provide an .onnx file as the first arg");
+
+    let environment = environment::Environment::builder()
+        .with_name("onnx metadata")
+        .with_log_level(onnxruntime::LoggingLevel::Verbose)
+        .build()?;
+
+    let session = environment
+        .new_session_builder()?
+        .with_optimization_level(onnxruntime::GraphOptimizationLevel::Basic)?
+        .with_model_from_file(path)?;
+
+    println!("Inputs:");
+    for (index, input) in session.inputs.iter().enumerate() {
+        println!(
+            "  {}:\n    name = {}\n    type = {:?}\n    dimensions = {:?}",
+            index, input.name, input.input_type, input.dimensions
+        )
+    }
+
+    println!("Outputs:");
+    for (index, output) in session.outputs.iter().enumerate() {
+        println!(
+            "  {}:\n    name = {}\n    type = {:?}\n    dimensions = {:?}",
+            index, output.name, output.output_type, output.dimensions
+        );
+    }
+
+    Ok(())
+}

--- a/onnxruntime/src/error.rs
+++ b/onnxruntime/src/error.rs
@@ -56,9 +56,15 @@ pub enum OrtError {
     /// Error occurred when creating CPU memory information
     #[error("Failed to get dimensions: {0}")]
     CreateCpuMemoryInfo(OrtApiError),
+    /// Error occurred when creating ONNX tensor
+    #[error("Failed to create tensor: {0}")]
+    CreateTensor(OrtApiError),
     /// Error occurred when creating ONNX tensor with specific data
     #[error("Failed to create tensor with data: {0}")]
     CreateTensorWithData(OrtApiError),
+    /// Error occurred when filling a tensor with string data
+    #[error("Failed to fill string tensor: {0}")]
+    FillStringTensor(OrtApiError),
     /// Error occurred when checking if ONNX tensor was properly initialized
     #[error("Failed to check if tensor: {0}")]
     IsTensor(OrtApiError),
@@ -183,4 +189,11 @@ pub(crate) fn status_to_result(
 ) -> std::result::Result<(), OrtApiError> {
     let status_wrapper: OrtStatusWrapper = status.into();
     status_wrapper.into()
+}
+
+/// A wrapper around a function on OrtApi that maps the status code into [OrtApiError]
+pub(crate) unsafe fn call_ort<F: FnMut(sys::OrtApi) -> *const sys::OrtStatus>(
+    mut block: F,
+) -> std::result::Result<(), OrtApiError> {
+    status_to_result(block(g_ort()))
 }

--- a/onnxruntime/src/error.rs
+++ b/onnxruntime/src/error.rs
@@ -192,8 +192,9 @@ pub(crate) fn status_to_result(
 }
 
 /// A wrapper around a function on OrtApi that maps the status code into [OrtApiError]
-pub(crate) unsafe fn call_ort<F: FnMut(sys::OrtApi) -> *const sys::OrtStatus>(
-    mut block: F,
-) -> std::result::Result<(), OrtApiError> {
-    status_to_result(block(g_ort()))
+pub(crate) unsafe fn call_ort<F>(mut f: F) -> std::result::Result<(), OrtApiError>
+where
+    F: FnMut(sys::OrtApi) -> *const sys::OrtStatus,
+{
+    status_to_result(f(g_ort()))
 }

--- a/onnxruntime/src/error.rs
+++ b/onnxruntime/src/error.rs
@@ -173,10 +173,9 @@ impl From<OrtStatusWrapper> for std::result::Result<(), OrtApiError> {
             match char_p_to_string(raw) {
                 Ok(msg) => Err(OrtApiError::Msg(msg)),
                 Err(err) => match err {
-                    OrtError::StringConversion(e) => match e {
-                        OrtApiError::IntoStringError(e) => Err(OrtApiError::IntoStringError(e)),
-                        _ => unreachable!(),
-                    },
+                    OrtError::StringConversion(OrtApiError::IntoStringError(e)) => {
+                        Err(OrtApiError::IntoStringError(e))
+                    }
                     _ => unreachable!(),
                 },
             }

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -411,7 +411,9 @@ impl<'a> Session<'a> {
         // The C API expects pointers for the arrays (pointers to C-arrays)
         let input_ort_tensors: Vec<OrtTensor<TIn, D>> = input_arrays
             .into_iter()
-            .map(|input_array| OrtTensor::from_array(&self.memory_info, input_array))
+            .map(|input_array| {
+                OrtTensor::from_array(&self.memory_info, self.allocator_ptr, input_array)
+            })
             .collect::<Result<Vec<OrtTensor<TIn, D>>>>()?;
         let input_ort_values: Vec<*const sys::OrtValue> = input_ort_tensors
             .iter()

--- a/onnxruntime/src/tensor/ort_tensor.rs
+++ b/onnxruntime/src/tensor/ort_tensor.rs
@@ -249,7 +249,7 @@ mod tests {
     }
 
     #[test]
-    fn orttensor_from_array_3d_string() {
+    fn orttensor_from_array_3d_str() {
         let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default).unwrap();
         let array = arr3(&[
             [["1", "2", "3"], ["4", "5", "6"]],

--- a/onnxruntime/src/tensor/ort_tensor.rs
+++ b/onnxruntime/src/tensor/ort_tensor.rs
@@ -1,6 +1,6 @@
 //! Module containing tensor with memory owned by Rust
 
-use std::{fmt::Debug, ops::Deref};
+use std::{ffi, fmt::Debug, ops::Deref};
 
 use ndarray::Array;
 use tracing::{debug, error};
@@ -8,8 +8,9 @@ use tracing::{debug, error};
 use onnxruntime_sys as sys;
 
 use crate::{
-    error::status_to_result, g_ort, memory::MemoryInfo, tensor::ndarray_tensor::NdArrayTensor,
-    OrtError, Result, TypeToTensorElementDataType,
+    error::call_ort, error::status_to_result, g_ort, memory::MemoryInfo,
+    tensor::ndarray_tensor::NdArrayTensor, OrtError, Result, TensorElementDataType,
+    TypeToTensorElementDataType,
 };
 
 /// Owned tensor, backed by an [`ndarray::Array`](https://docs.rs/ndarray/latest/ndarray/type.Array.html)
@@ -37,38 +38,103 @@ where
 {
     pub(crate) fn from_array<'m>(
         memory_info: &'m MemoryInfo,
+        allocator_ptr: *mut sys::OrtAllocator,
         mut array: Array<T, D>,
     ) -> Result<OrtTensor<'t, T, D>>
     where
         'm: 't, // 'm outlives 't
     {
+        // where onnxruntime will write the tensor data to
         let mut tensor_ptr: *mut sys::OrtValue = std::ptr::null_mut();
         let tensor_ptr_ptr: *mut *mut sys::OrtValue = &mut tensor_ptr;
-        let tensor_values_ptr: *mut std::ffi::c_void = array.as_mut_ptr() as *mut std::ffi::c_void;
-        assert_ne!(tensor_values_ptr, std::ptr::null_mut());
 
         let shape: Vec<i64> = array.shape().iter().map(|d: &usize| *d as i64).collect();
         let shape_ptr: *const i64 = shape.as_ptr();
         let shape_len = array.shape().len() as u64;
 
-        let status = unsafe {
-            g_ort().CreateTensorWithDataAsOrtValue.unwrap()(
-                memory_info.ptr,
-                tensor_values_ptr,
-                (array.len() * std::mem::size_of::<T>()) as u64,
-                shape_ptr,
-                shape_len,
-                T::tensor_element_data_type(),
-                tensor_ptr_ptr,
-            )
-        };
-        status_to_result(status).map_err(OrtError::CreateTensorWithData)?;
-        assert_ne!(tensor_ptr, std::ptr::null_mut());
+        match T::tensor_element_data_type() {
+            TensorElementDataType::Float
+            | TensorElementDataType::Uint8
+            | TensorElementDataType::Int8
+            | TensorElementDataType::Uint16
+            | TensorElementDataType::Int16
+            | TensorElementDataType::Int32
+            | TensorElementDataType::Int64
+            | TensorElementDataType::Double
+            | TensorElementDataType::Uint32
+            | TensorElementDataType::Uint64 => {
+                // primitive data is already suitably laid out in memory; provide it to
+                // onnxruntime as is
+                let tensor_values_ptr: *mut std::ffi::c_void =
+                    array.as_mut_ptr() as *mut std::ffi::c_void;
+                assert_ne!(tensor_values_ptr, std::ptr::null_mut());
 
-        let mut is_tensor = 0;
-        let status = unsafe { g_ort().IsTensor.unwrap()(tensor_ptr, &mut is_tensor) };
-        status_to_result(status).map_err(OrtError::IsTensor)?;
-        assert_eq!(is_tensor, 1);
+                unsafe {
+                    call_ort(|ort| {
+                        ort.CreateTensorWithDataAsOrtValue.unwrap()(
+                            memory_info.ptr,
+                            tensor_values_ptr,
+                            (array.len() * std::mem::size_of::<T>()) as u64,
+                            shape_ptr,
+                            shape_len,
+                            T::tensor_element_data_type().into(),
+                            tensor_ptr_ptr,
+                        )
+                    })
+                }
+                .map_err(OrtError::CreateTensorWithData)?;
+                assert_ne!(tensor_ptr, std::ptr::null_mut());
+
+                let mut is_tensor = 0;
+                let status = unsafe { g_ort().IsTensor.unwrap()(tensor_ptr, &mut is_tensor) };
+                status_to_result(status).map_err(OrtError::IsTensor)?;
+            }
+            TensorElementDataType::String => {
+                // create tensor without data -- data is filled in later
+                unsafe {
+                    call_ort(|ort| {
+                        ort.CreateTensorAsOrtValue.unwrap()(
+                            allocator_ptr,
+                            shape_ptr,
+                            shape_len,
+                            T::tensor_element_data_type().into(),
+                            tensor_ptr_ptr,
+                        )
+                    })
+                }
+                .map_err(OrtError::CreateTensor)?;
+
+                // create null-terminated copies of each string, as per `FillStringTensor` docs
+                let null_terminated_copies: Vec<ffi::CString> = array
+                    .iter()
+                    .map(|elt| {
+                        let slice = elt
+                            .try_utf8_bytes()
+                            .expect("String data type must provide utf8 bytes");
+                        ffi::CString::new(slice)
+                    })
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .map_err(OrtError::CStringNulError)?;
+
+                let string_pointers = null_terminated_copies
+                    .iter()
+                    .map(|cstring| cstring.as_ptr())
+                    .collect::<Vec<_>>();
+
+                unsafe {
+                    call_ort(|ort| {
+                        ort.FillStringTensor.unwrap()(
+                            tensor_ptr,
+                            string_pointers.as_ptr(),
+                            string_pointers.len() as u64,
+                        )
+                    })
+                }
+                .map_err(OrtError::FillStringTensor)?;
+            }
+        }
+
+        assert_ne!(tensor_ptr, std::ptr::null_mut());
 
         Ok(OrtTensor {
             c_ptr: tensor_ptr,
@@ -129,13 +195,14 @@ mod tests {
     use super::*;
     use crate::{AllocatorType, MemType};
     use ndarray::{arr0, arr1, arr2, arr3};
+    use std::ptr;
     use test_env_log::test;
 
     #[test]
     fn orttensor_from_array_0d_i32() {
         let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default).unwrap();
         let array = arr0::<i32>(123);
-        let tensor = OrtTensor::from_array(&memory_info, array).unwrap();
+        let tensor = OrtTensor::from_array(&memory_info, ptr::null_mut(), array).unwrap();
         let expected_shape: &[usize] = &[];
         assert_eq!(tensor.shape(), expected_shape);
     }
@@ -144,7 +211,7 @@ mod tests {
     fn orttensor_from_array_1d_i32() {
         let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default).unwrap();
         let array = arr1(&[1_i32, 2, 3, 4, 5, 6]);
-        let tensor = OrtTensor::from_array(&memory_info, array).unwrap();
+        let tensor = OrtTensor::from_array(&memory_info, ptr::null_mut(), array).unwrap();
         let expected_shape: &[usize] = &[6];
         assert_eq!(tensor.shape(), expected_shape);
     }
@@ -153,7 +220,7 @@ mod tests {
     fn orttensor_from_array_2d_i32() {
         let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default).unwrap();
         let array = arr2(&[[1_i32, 2, 3, 4, 5, 6], [7, 8, 9, 10, 11, 12]]);
-        let tensor = OrtTensor::from_array(&memory_info, array).unwrap();
+        let tensor = OrtTensor::from_array(&memory_info, ptr::null_mut(), array).unwrap();
         assert_eq!(tensor.shape(), &[2, 6]);
     }
 
@@ -165,7 +232,40 @@ mod tests {
             [[13, 14, 15, 16, 17, 18], [19, 20, 21, 22, 23, 24]],
             [[25, 26, 27, 28, 29, 30], [31, 32, 33, 34, 35, 36]],
         ]);
-        let tensor = OrtTensor::from_array(&memory_info, array).unwrap();
+        let tensor = OrtTensor::from_array(&memory_info, ptr::null_mut(), array).unwrap();
         assert_eq!(tensor.shape(), &[3, 2, 6]);
+    }
+
+    #[test]
+    fn orttensor_from_array_1d_string() {
+        let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default).unwrap();
+        let array = arr1(&[
+            String::from("foo"),
+            String::from("bar"),
+            String::from("baz"),
+        ]);
+        let tensor = OrtTensor::from_array(&memory_info, ort_default_allocator(), array).unwrap();
+        assert_eq!(tensor.shape(), &[3]);
+    }
+
+    #[test]
+    fn orttensor_from_array_3d_string() {
+        let memory_info = MemoryInfo::new(AllocatorType::Arena, MemType::Default).unwrap();
+        let array = arr3(&[
+            [["1", "2", "3"], ["4", "5", "6"]],
+            [["7", "8", "9"], ["10", "11", "12"]],
+        ]);
+        let tensor = OrtTensor::from_array(&memory_info, ort_default_allocator(), array).unwrap();
+        assert_eq!(tensor.shape(), &[2, 2, 3]);
+    }
+
+    fn ort_default_allocator() -> *mut sys::OrtAllocator {
+        let mut allocator_ptr: *mut sys::OrtAllocator = std::ptr::null_mut();
+        unsafe {
+            // this default non-arena allocator doesn't need to be deallocated
+            call_ort(|ort| ort.GetAllocatorWithDefaultOptions.unwrap()(&mut allocator_ptr))
+        }
+        .unwrap();
+        allocator_ptr
     }
 }


### PR DESCRIPTION
- Tensor construction now uses different logic for primitive types (using their native in-memory layout) and strings (filling the tensor with onnxruntime's `FillStringTensor`).
  - Extended `TypeToTensorElementDataType` to also be able to expose utf8 contents, if present
  - `Utf8Data` trait to make it possible to use both `String` and `&str`
- `call_ort` helper that takes care of mapping the ort status to a Result so you can't forget to do it
- `print_structure` example that shows the inputs and outputs of an .onnx model (names, types, etc)

---

Without this, interacting with session inputs for a model with a string input would lead to `SIGABRT` as the auto-generated Debug, etc, didn't know what to do with an enum variant of `8` (onnxruntime's string type).

If this looks good, I'll work on an integration test with a trivial model to ensure that feeding data through actually does work, but I wanted to get feedback on the approach first.