### PR TITLE
Fix win32 build

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -97,20 +97,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [
-          ubuntu-latest,
-          macos-latest,
-          windows-latest
-        ]
+        target:
+          [
+            x86_64-unknown-linux-gnu,
+            x86_64-apple-darwin,
+            x86_64-pc-windows-msvc,
+            i686-pc-windows-msvc,
+          ]
         include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: macos-latest
-            target: x86_64-apple-darwin
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-          - os: windows-latest
-            target: i686-pc-windows-msvc
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: i686-pc-windows-msvc
+            os: windows-latest
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
     steps:

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -54,14 +54,14 @@ jobs:
           args: --target x86_64-apple-darwin
       - name: Verify prebuilt archive downloaded (CPU, x86_64-apple-darwin)
         run: ls -lh target/x86_64-apple-darwin/debug/build/onnxruntime-sys-*/out/onnxruntime-osx-x64-1.*.tgz
-      # # ******************************************************************
-      # - name: Download prebuilt archive (CPU, i686-pc-windows-msvc)
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: build
-      #     args: --target i686-pc-windows-msvc
-      # - name: Verify prebuilt archive downloaded (CPU, i686-pc-windows-msvc)
-      #   run: ls -lh target/i686-pc-windows-msvc/debug/build/onnxruntime-sys-*/out/onnxruntime-win-x86-1.*.zip
+      # ******************************************************************
+      - name: Download prebuilt archive (CPU, i686-pc-windows-msvc)
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target i686-pc-windows-msvc
+      - name: Verify prebuilt archive downloaded (CPU, i686-pc-windows-msvc)
+        run: ls -lh target/i686-pc-windows-msvc/debug/build/onnxruntime-sys-*/out/onnxruntime-win-x86-1.*.zip
       # ******************************************************************
       - name: Download prebuilt archive (CPU, x86_64-pc-windows-msvc)
         uses: actions-rs/cargo@v1
@@ -109,8 +109,8 @@ jobs:
             target: x86_64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-          # - os: windows-latest
-          #   target: i686-pc-windows-msvc
+          - os: windows-latest
+            target: i686-pc-windows-msvc
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
     steps:

--- a/onnxruntime-sys/build.rs
+++ b/onnxruntime-sys/build.rs
@@ -84,6 +84,8 @@ fn generate_bindings(include_dir: &Path) {
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Set `size_t` to be translated to `usize` for win32 compatibility.
+        .size_t_is_usize(true)
         // Format using rustfmt
         .rustfmt_bindings(true)
         .rustified_enum("*")

--- a/onnxruntime-sys/examples/c_api_sample.rs
+++ b/onnxruntime-sys/examples/c_api_sample.rs
@@ -103,7 +103,7 @@ fn main() {
     assert_ne!(allocator_ptr, std::ptr::null_mut());
 
     // print number of model input nodes
-    let mut num_input_nodes: onnxruntime_sys::size_t = 0;
+    let mut num_input_nodes: usize = 0;
     let status = unsafe {
         g_ort.as_ref().unwrap().SessionGetInputCount.unwrap()(session_ptr, &mut num_input_nodes)
     };
@@ -255,7 +255,7 @@ fn main() {
             .unwrap()(
             memory_info_ptr,
             input_tensor_values_ptr,
-            (input_tensor_size * std::mem::size_of::<f32>()) as onnxruntime_sys::size_t,
+            input_tensor_size * std::mem::size_of::<f32>(),
             shape,
             4,
             ONNXTensorElementDataType::ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT,

--- a/onnxruntime-sys/src/generated/linux/x86_64/bindings.rs
+++ b/onnxruntime-sys/src/generated/linux/x86_64/bindings.rs
@@ -23,9 +23,10 @@ pub const _STDC_PREDEF_H: u32 = 1;
 pub const __STDC_IEC_559__: u32 = 1;
 pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
+pub const __STDC_NO_THREADS__: u32 = 1;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 28;
+pub const __GLIBC_MINOR__: u32 = 27;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __WORDSIZE: u32 = 64;
@@ -101,6 +102,8 @@ pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
 pub const FD_SETSIZE: u32 = 1024;
+pub const _SYS_SYSMACROS_H: u32 = 1;
+pub const _BITS_SYSMACROS_H: u32 = 1;
 pub const _BITS_PTHREADTYPES_COMMON_H: u32 = 1;
 pub const _THREAD_SHARED_TYPES_H: u32 = 1;
 pub const _BITS_PTHREADTYPES_ARCH_H: u32 = 1;
@@ -165,7 +168,6 @@ pub const _BITS_TYPES_LOCALE_T_H: u32 = 1;
 pub const _BITS_TYPES___LOCALE_T_H: u32 = 1;
 pub const _STRINGS_H: u32 = 1;
 pub const ORT_API_VERSION: u32 = 6;
-pub type size_t = ::std::os::raw::c_ulong;
 pub type wchar_t = ::std::os::raw::c_int;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -296,7 +298,7 @@ fn bindgen_test_layout_lldiv_t() {
     );
 }
 extern "C" {
-    pub fn __ctype_get_mb_cur_max() -> size_t;
+    pub fn __ctype_get_mb_cur_max() -> usize;
 }
 extern "C" {
     pub fn atof(__nptr: *const ::std::os::raw::c_char) -> f64;
@@ -388,14 +390,6 @@ pub type __int32_t = ::std::os::raw::c_int;
 pub type __uint32_t = ::std::os::raw::c_uint;
 pub type __int64_t = ::std::os::raw::c_long;
 pub type __uint64_t = ::std::os::raw::c_ulong;
-pub type __int_least8_t = __int8_t;
-pub type __uint_least8_t = __uint8_t;
-pub type __int_least16_t = __int16_t;
-pub type __uint_least16_t = __uint16_t;
-pub type __int_least32_t = __int32_t;
-pub type __uint_least32_t = __uint32_t;
-pub type __int_least64_t = __int64_t;
-pub type __uint_least64_t = __uint64_t;
 pub type __quad_t = ::std::os::raw::c_long;
 pub type __u_quad_t = ::std::os::raw::c_ulong;
 pub type __intmax_t = ::std::os::raw::c_long;
@@ -482,7 +476,6 @@ pub type uid_t = __uid_t;
 pub type off_t = __off_t;
 pub type pid_t = __pid_t;
 pub type id_t = __id_t;
-pub type ssize_t = __ssize_t;
 pub type daddr_t = __daddr_t;
 pub type caddr_t = __caddr_t;
 pub type key_t = __key_t;
@@ -654,6 +647,18 @@ extern "C" {
         __timeout: *const timespec,
         __sigmask: *const __sigset_t,
     ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn gnu_dev_major(__dev: __dev_t) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn gnu_dev_minor(__dev: __dev_t) -> ::std::os::raw::c_uint;
+}
+extern "C" {
+    pub fn gnu_dev_makedev(
+        __major: ::std::os::raw::c_uint,
+        __minor: ::std::os::raw::c_uint,
+    ) -> __dev_t;
 }
 pub type blksize_t = __blksize_t;
 pub type blkcnt_t = __blkcnt_t;
@@ -1640,7 +1645,7 @@ extern "C" {
     pub fn initstate(
         __seed: ::std::os::raw::c_uint,
         __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: size_t,
+        __statelen: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -1753,7 +1758,7 @@ extern "C" {
     pub fn initstate_r(
         __seed: ::std::os::raw::c_uint,
         __statebuf: *mut ::std::os::raw::c_char,
-        __statelen: size_t,
+        __statelen: usize,
         __buf: *mut random_data,
     ) -> ::std::os::raw::c_int;
 }
@@ -1947,17 +1952,17 @@ extern "C" {
     pub fn alloca(__size: ::std::os::raw::c_ulong) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    pub fn valloc(__size: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn valloc(__size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn posix_memalign(
         __memptr: *mut *mut ::std::os::raw::c_void,
-        __alignment: size_t,
-        __size: size_t,
+        __alignment: usize,
+        __size: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn aligned_alloc(__alignment: size_t, __size: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn abort();
@@ -2043,16 +2048,16 @@ extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nmemb: size_t,
-        __size: size_t,
+        __nmemb: usize,
+        __size: usize,
         __compar: __compar_fn_t,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn qsort(
         __base: *mut ::std::os::raw::c_void,
-        __nmemb: size_t,
-        __size: size_t,
+        __nmemb: usize,
+        __size: usize,
         __compar: __compar_fn_t,
     );
 }
@@ -2130,7 +2135,7 @@ extern "C" {
         __decpt: *mut ::std::os::raw::c_int,
         __sign: *mut ::std::os::raw::c_int,
         __buf: *mut ::std::os::raw::c_char,
-        __len: size_t,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2140,7 +2145,7 @@ extern "C" {
         __decpt: *mut ::std::os::raw::c_int,
         __sign: *mut ::std::os::raw::c_int,
         __buf: *mut ::std::os::raw::c_char,
-        __len: size_t,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2150,7 +2155,7 @@ extern "C" {
         __decpt: *mut ::std::os::raw::c_int,
         __sign: *mut ::std::os::raw::c_int,
         __buf: *mut ::std::os::raw::c_char,
-        __len: size_t,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2160,35 +2165,27 @@ extern "C" {
         __decpt: *mut ::std::os::raw::c_int,
         __sign: *mut ::std::os::raw::c_int,
         __buf: *mut ::std::os::raw::c_char,
-        __len: size_t,
+        __len: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn mblen(__s: *const ::std::os::raw::c_char, __n: size_t) -> ::std::os::raw::c_int;
+    pub fn mblen(__s: *const ::std::os::raw::c_char, __n: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn mbtowc(
         __pwc: *mut wchar_t,
         __s: *const ::std::os::raw::c_char,
-        __n: size_t,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn wctomb(__s: *mut ::std::os::raw::c_char, __wchar: wchar_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn mbstowcs(
-        __pwcs: *mut wchar_t,
-        __s: *const ::std::os::raw::c_char,
-        __n: size_t,
-    ) -> size_t;
+    pub fn mbstowcs(__pwcs: *mut wchar_t, __s: *const ::std::os::raw::c_char, __n: usize) -> usize;
 }
 extern "C" {
-    pub fn wcstombs(
-        __s: *mut ::std::os::raw::c_char,
-        __pwcs: *const wchar_t,
-        __n: size_t,
-    ) -> size_t;
+    pub fn wcstombs(__s: *mut ::std::os::raw::c_char, __pwcs: *const wchar_t, __n: usize) -> usize;
 }
 extern "C" {
     pub fn rpmatch(__response: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
@@ -2204,14 +2201,14 @@ extern "C" {
     pub fn getloadavg(__loadavg: *mut f64, __nelem: ::std::os::raw::c_int)
         -> ::std::os::raw::c_int;
 }
-pub type int_least8_t = __int_least8_t;
-pub type int_least16_t = __int_least16_t;
-pub type int_least32_t = __int_least32_t;
-pub type int_least64_t = __int_least64_t;
-pub type uint_least8_t = __uint_least8_t;
-pub type uint_least16_t = __uint_least16_t;
-pub type uint_least32_t = __uint_least32_t;
-pub type uint_least64_t = __uint_least64_t;
+pub type int_least8_t = ::std::os::raw::c_schar;
+pub type int_least16_t = ::std::os::raw::c_short;
+pub type int_least32_t = ::std::os::raw::c_int;
+pub type int_least64_t = ::std::os::raw::c_long;
+pub type uint_least8_t = ::std::os::raw::c_uchar;
+pub type uint_least16_t = ::std::os::raw::c_ushort;
+pub type uint_least32_t = ::std::os::raw::c_uint;
+pub type uint_least64_t = ::std::os::raw::c_ulong;
 pub type int_fast8_t = ::std::os::raw::c_schar;
 pub type int_fast16_t = ::std::os::raw::c_long;
 pub type int_fast32_t = ::std::os::raw::c_long;
@@ -2241,7 +2238,7 @@ extern "C" {
         __dest: *mut ::std::os::raw::c_void,
         __src: *const ::std::os::raw::c_void,
         __c: ::std::os::raw::c_int,
-        __n: size_t,
+        __n: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -2402,9 +2399,9 @@ extern "C" {
     pub fn strxfrm_l(
         __dest: *mut ::std::os::raw::c_char,
         __src: *const ::std::os::raw::c_char,
-        __n: size_t,
+        __n: usize,
         __l: locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn strdup(__s: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
@@ -2475,7 +2472,7 @@ extern "C" {
     pub fn strlen(__s: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulong;
 }
 extern "C" {
-    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: size_t) -> size_t;
+    pub fn strnlen(__string: *const ::std::os::raw::c_char, __maxlen: usize) -> usize;
 }
 extern "C" {
     pub fn strerror(__errnum: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
@@ -2485,7 +2482,7 @@ extern "C" {
     pub fn strerror_r(
         __errnum: ::std::os::raw::c_int,
         __buf: *mut ::std::os::raw::c_char,
-        __buflen: size_t,
+        __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2498,14 +2495,14 @@ extern "C" {
     pub fn bcmp(
         __s1: *const ::std::os::raw::c_void,
         __s2: *const ::std::os::raw::c_void,
-        __n: size_t,
+        __n: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn bcopy(
         __src: *const ::std::os::raw::c_void,
         __dest: *mut ::std::os::raw::c_void,
-        __n: size_t,
+        __n: usize,
     );
 }
 extern "C" {
@@ -2556,12 +2553,12 @@ extern "C" {
     pub fn strncasecmp_l(
         __s1: *const ::std::os::raw::c_char,
         __s2: *const ::std::os::raw::c_char,
-        __n: size_t,
+        __n: usize,
         __loc: locale_t,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: size_t);
+    pub fn explicit_bzero(__s: *mut ::std::os::raw::c_void, __n: usize);
 }
 extern "C" {
     pub fn strsep(
@@ -2588,7 +2585,7 @@ extern "C" {
     pub fn __stpncpy(
         __dest: *mut ::std::os::raw::c_char,
         __src: *const ::std::os::raw::c_char,
-        __n: size_t,
+        __n: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2745,7 +2742,7 @@ pub type OrtStatusPtr = *mut OrtStatus;
 pub struct OrtAllocator {
     pub version: u32,
     pub Alloc: ::std::option::Option<
-        unsafe extern "C" fn(this_: *mut OrtAllocator, size: size_t) -> *mut ::std::os::raw::c_void,
+        unsafe extern "C" fn(this_: *mut OrtAllocator, size: usize) -> *mut ::std::os::raw::c_void,
     >,
     pub Free: ::std::option::Option<
         unsafe extern "C" fn(this_: *mut OrtAllocator, p: *mut ::std::os::raw::c_void),
@@ -2886,7 +2883,7 @@ pub enum OrtCudnnConvAlgoSearch {
 pub struct OrtCUDAProviderOptions {
     pub device_id: ::std::os::raw::c_int,
     pub cudnn_conv_algo_search: OrtCudnnConvAlgoSearch,
-    pub cuda_mem_limit: size_t,
+    pub cuda_mem_limit: usize,
     pub arena_extend_strategy: ::std::os::raw::c_int,
     pub do_copy_in_default_stream: ::std::os::raw::c_int,
 }
@@ -2975,7 +2972,7 @@ pub struct OrtOpenVINOProviderOptions {
     pub device_type: *const ::std::os::raw::c_char,
     pub enable_vpu_fast_compile: ::std::os::raw::c_uchar,
     pub device_id: *const ::std::os::raw::c_char,
-    pub num_of_threads: size_t,
+    pub num_of_threads: usize,
 }
 #[test]
 fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
@@ -3132,7 +3129,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             env: *const OrtEnv,
             model_data: *const ::std::os::raw::c_void,
-            model_data_length: size_t,
+            model_data_length: usize,
             options: *const OrtSessionOptions,
             out: *mut *mut OrtSession,
         ) -> OrtStatusPtr,
@@ -3143,9 +3140,9 @@ pub struct OrtApi {
             run_options: *const OrtRunOptions,
             input_names: *const *const ::std::os::raw::c_char,
             input: *const *const OrtValue,
-            input_len: size_t,
+            input_len: usize,
             output_names1: *const *const ::std::os::raw::c_char,
-            output_names_len: size_t,
+            output_names_len: usize,
             output: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -3253,39 +3250,39 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub SessionGetInputCount: ::std::option::Option<
-        unsafe extern "C" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetOutputCount: ::std::option::Option<
-        unsafe extern "C" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetOverridableInitializerCount: ::std::option::Option<
-        unsafe extern "C" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetInputTypeInfo: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetOutputTypeInfo: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetOverridableInitializerTypeInfo: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetInputName: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -3293,7 +3290,7 @@ pub struct OrtApi {
     pub SessionGetOutputName: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -3301,7 +3298,7 @@ pub struct OrtApi {
     pub SessionGetOverridableInitializerName: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -3352,7 +3349,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             allocator: *mut OrtAllocator,
             shape: *const i64,
-            shape_len: size_t,
+            shape_len: usize,
             type_: ONNXTensorElementDataType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -3361,9 +3358,9 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             info: *const OrtMemoryInfo,
             p_data: *mut ::std::os::raw::c_void,
-            p_data_len: size_t,
+            p_data_len: usize,
             shape: *const i64,
-            shape_len: size_t,
+            shape_len: usize,
             type_: ONNXTensorElementDataType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -3384,19 +3381,19 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             value: *mut OrtValue,
             s: *const *const ::std::os::raw::c_char,
-            s_len: size_t,
+            s_len: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetStringTensorDataLength: ::std::option::Option<
-        unsafe extern "C" fn(value: *const OrtValue, len: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(value: *const OrtValue, len: *mut usize) -> OrtStatusPtr,
     >,
     pub GetStringTensorContent: ::std::option::Option<
         unsafe extern "C" fn(
             value: *const OrtValue,
             s: *mut ::std::os::raw::c_void,
-            s_len: size_t,
-            offsets: *mut size_t,
-            offsets_len: size_t,
+            s_len: usize,
+            offsets: *mut usize,
+            offsets_len: usize,
         ) -> OrtStatusPtr,
     >,
     pub CastTypeInfoToTensorInfo: ::std::option::Option<
@@ -3421,7 +3418,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             info: *mut OrtTensorTypeAndShapeInfo,
             dim_values: *const i64,
-            dim_count: size_t,
+            dim_count: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorElementType: ::std::option::Option<
@@ -3433,27 +3430,27 @@ pub struct OrtApi {
     pub GetDimensionsCount: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetDimensions: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
             dim_values: *mut i64,
-            dim_values_length: size_t,
+            dim_values_length: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetSymbolicDimensions: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
             dim_params: *mut *const ::std::os::raw::c_char,
-            dim_params_length: size_t,
+            dim_params_length: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorShapeElementCount: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorTypeAndShape: ::std::option::Option<
@@ -3512,7 +3509,7 @@ pub struct OrtApi {
     pub AllocatorAlloc: ::std::option::Option<
         unsafe extern "C" fn(
             ptr: *mut OrtAllocator,
-            size: size_t,
+            size: usize,
             out: *mut *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -3546,12 +3543,12 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub GetValueCount: ::std::option::Option<
-        unsafe extern "C" fn(value: *const OrtValue, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(value: *const OrtValue, out: *mut usize) -> OrtStatusPtr,
     >,
     pub CreateValue: ::std::option::Option<
         unsafe extern "C" fn(
             in_: *const *const OrtValue,
-            num_values: size_t,
+            num_values: usize,
             value_type: ONNXType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -3561,7 +3558,7 @@ pub struct OrtApi {
             domain_name: *const ::std::os::raw::c_char,
             type_name: *const ::std::os::raw::c_char,
             data_container: *const ::std::os::raw::c_void,
-            data_container_size: size_t,
+            data_container_size: usize,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -3571,7 +3568,7 @@ pub struct OrtApi {
             type_name: *const ::std::os::raw::c_char,
             in_: *const OrtValue,
             data_container: *mut ::std::os::raw::c_void,
-            data_container_size: size_t,
+            data_container_size: usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelInfoGetAttribute_float: ::std::option::Option<
@@ -3593,28 +3590,28 @@ pub struct OrtApi {
             info: *const OrtKernelInfo,
             name: *const ::std::os::raw::c_char,
             out: *mut ::std::os::raw::c_char,
-            size: *mut size_t,
+            size: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetInputCount: ::std::option::Option<
-        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr,
     >,
     pub KernelContext_GetOutputCount: ::std::option::Option<
-        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr,
     >,
     pub KernelContext_GetInput: ::std::option::Option<
         unsafe extern "C" fn(
             context: *const OrtKernelContext,
-            index: size_t,
+            index: usize,
             out: *mut *const OrtValue,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetOutput: ::std::option::Option<
         unsafe extern "C" fn(
             context: *mut OrtKernelContext,
-            index: size_t,
+            index: usize,
             dim_values: *const i64,
-            dim_count: size_t,
+            dim_count: usize,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -3635,7 +3632,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             arg1: *const OrtTypeInfo,
             denotation: *mut *const ::std::os::raw::c_char,
-            len: *mut size_t,
+            len: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub CastTypeInfoToMapTypeInfo: ::std::option::Option<
@@ -3772,17 +3769,13 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub GetStringTensorElementLength: ::std::option::Option<
-        unsafe extern "C" fn(
-            value: *const OrtValue,
-            index: size_t,
-            out: *mut size_t,
-        ) -> OrtStatusPtr,
+        unsafe extern "C" fn(value: *const OrtValue, index: usize, out: *mut usize) -> OrtStatusPtr,
     >,
     pub GetStringTensorElement: ::std::option::Option<
         unsafe extern "C" fn(
             value: *const OrtValue,
-            s_len: size_t,
-            index: size_t,
+            s_len: usize,
+            index: usize,
             s: *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -3790,7 +3783,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             value: *mut OrtValue,
             s: *const ::std::os::raw::c_char,
-            index: size_t,
+            index: usize,
         ) -> OrtStatusPtr,
     >,
     pub AddSessionConfigEntry: ::std::option::Option<
@@ -3845,8 +3838,8 @@ pub struct OrtApi {
             binding_ptr: *const OrtIoBinding,
             allocator: *mut OrtAllocator,
             buffer: *mut *mut ::std::os::raw::c_char,
-            lengths: *mut *mut size_t,
-            count: *mut size_t,
+            lengths: *mut *mut usize,
+            count: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetBoundOutputValues: ::std::option::Option<
@@ -3854,7 +3847,7 @@ pub struct OrtApi {
             binding_ptr: *const OrtIoBinding,
             allocator: *mut OrtAllocator,
             output: *mut *mut *mut OrtValue,
-            output_count: *mut size_t,
+            output_count: *mut usize,
         ) -> OrtStatusPtr,
     >,
     #[doc = " Clears any previously specified bindings for inputs/outputs"]
@@ -3866,7 +3859,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             value: *mut OrtValue,
             location_values: *const i64,
-            location_values_count: size_t,
+            location_values_count: usize,
             out: *mut *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -3938,7 +3931,7 @@ pub struct OrtApi {
     >,
     pub CreateArenaCfg: ::std::option::Option<
         unsafe extern "C" fn(
-            max_mem: size_t,
+            max_mem: usize,
             arena_extend_strategy: ::std::os::raw::c_int,
             initial_chunk_size_bytes: ::std::os::raw::c_int,
             max_dead_bytes_per_chunk: ::std::os::raw::c_int,
@@ -5642,15 +5635,15 @@ pub struct OrtCustomOp {
         unsafe extern "C" fn(op: *const OrtCustomOp) -> *const ::std::os::raw::c_char,
     >,
     pub GetInputType: ::std::option::Option<
-        unsafe extern "C" fn(op: *const OrtCustomOp, index: size_t) -> ONNXTensorElementDataType,
+        unsafe extern "C" fn(op: *const OrtCustomOp, index: usize) -> ONNXTensorElementDataType,
     >,
     pub GetInputTypeCount:
-        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> size_t>,
+        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> usize>,
     pub GetOutputType: ::std::option::Option<
-        unsafe extern "C" fn(op: *const OrtCustomOp, index: size_t) -> ONNXTensorElementDataType,
+        unsafe extern "C" fn(op: *const OrtCustomOp, index: usize) -> ONNXTensorElementDataType,
     >,
     pub GetOutputTypeCount:
-        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> size_t>,
+        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> usize>,
     pub KernelCompute: ::std::option::Option<
         unsafe extern "C" fn(
             op_kernel: *mut ::std::os::raw::c_void,

--- a/onnxruntime-sys/src/generated/macos/x86_64/bindings.rs
+++ b/onnxruntime-sys/src/generated/macos/x86_64/bindings.rs
@@ -110,8 +110,13 @@ pub const __MAC_10_13_4: u32 = 101304;
 pub const __MAC_10_14: u32 = 101400;
 pub const __MAC_10_14_1: u32 = 101401;
 pub const __MAC_10_14_4: u32 = 101404;
+pub const __MAC_10_14_6: u32 = 101406;
 pub const __MAC_10_15: u32 = 101500;
 pub const __MAC_10_15_1: u32 = 101501;
+pub const __MAC_10_15_4: u32 = 101504;
+pub const __MAC_10_16: u32 = 101600;
+pub const __MAC_11_0: u32 = 110000;
+pub const __MAC_11_1: u32 = 110100;
 pub const __IPHONE_2_0: u32 = 20000;
 pub const __IPHONE_2_1: u32 = 20100;
 pub const __IPHONE_2_2: u32 = 20200;
@@ -150,9 +155,19 @@ pub const __IPHONE_12_0: u32 = 120000;
 pub const __IPHONE_12_1: u32 = 120100;
 pub const __IPHONE_12_2: u32 = 120200;
 pub const __IPHONE_12_3: u32 = 120300;
+pub const __IPHONE_12_4: u32 = 120400;
 pub const __IPHONE_13_0: u32 = 130000;
 pub const __IPHONE_13_1: u32 = 130100;
 pub const __IPHONE_13_2: u32 = 130200;
+pub const __IPHONE_13_3: u32 = 130300;
+pub const __IPHONE_13_4: u32 = 130400;
+pub const __IPHONE_13_5: u32 = 130500;
+pub const __IPHONE_13_6: u32 = 130600;
+pub const __IPHONE_13_7: u32 = 130700;
+pub const __IPHONE_14_0: u32 = 140000;
+pub const __IPHONE_14_1: u32 = 140100;
+pub const __IPHONE_14_2: u32 = 140200;
+pub const __IPHONE_14_3: u32 = 140300;
 pub const __TVOS_9_0: u32 = 90000;
 pub const __TVOS_9_1: u32 = 90100;
 pub const __TVOS_9_2: u32 = 90200;
@@ -169,8 +184,15 @@ pub const __TVOS_12_0: u32 = 120000;
 pub const __TVOS_12_1: u32 = 120100;
 pub const __TVOS_12_2: u32 = 120200;
 pub const __TVOS_12_3: u32 = 120300;
+pub const __TVOS_12_4: u32 = 120400;
 pub const __TVOS_13_0: u32 = 130000;
-pub const __TVOS_13_1: u32 = 130100;
+pub const __TVOS_13_2: u32 = 130200;
+pub const __TVOS_13_3: u32 = 130300;
+pub const __TVOS_13_4: u32 = 130400;
+pub const __TVOS_14_0: u32 = 140000;
+pub const __TVOS_14_1: u32 = 140100;
+pub const __TVOS_14_2: u32 = 140200;
+pub const __TVOS_14_3: u32 = 140300;
 pub const __WATCHOS_1_0: u32 = 10000;
 pub const __WATCHOS_2_0: u32 = 20000;
 pub const __WATCHOS_2_1: u32 = 20100;
@@ -186,14 +208,53 @@ pub const __WATCHOS_4_3: u32 = 40300;
 pub const __WATCHOS_5_0: u32 = 50000;
 pub const __WATCHOS_5_1: u32 = 50100;
 pub const __WATCHOS_5_2: u32 = 50200;
+pub const __WATCHOS_5_3: u32 = 50300;
 pub const __WATCHOS_6_0: u32 = 60000;
-pub const __WATCHOS_6_0_1: u32 = 60001;
+pub const __WATCHOS_6_1: u32 = 60100;
+pub const __WATCHOS_6_2: u32 = 60200;
+pub const __WATCHOS_7_0: u32 = 70000;
+pub const __WATCHOS_7_1: u32 = 70100;
+pub const __WATCHOS_7_2: u32 = 70200;
+pub const MAC_OS_X_VERSION_10_0: u32 = 1000;
+pub const MAC_OS_X_VERSION_10_1: u32 = 1010;
+pub const MAC_OS_X_VERSION_10_2: u32 = 1020;
+pub const MAC_OS_X_VERSION_10_3: u32 = 1030;
+pub const MAC_OS_X_VERSION_10_4: u32 = 1040;
+pub const MAC_OS_X_VERSION_10_5: u32 = 1050;
+pub const MAC_OS_X_VERSION_10_6: u32 = 1060;
+pub const MAC_OS_X_VERSION_10_7: u32 = 1070;
+pub const MAC_OS_X_VERSION_10_8: u32 = 1080;
+pub const MAC_OS_X_VERSION_10_9: u32 = 1090;
+pub const MAC_OS_X_VERSION_10_10: u32 = 101000;
+pub const MAC_OS_X_VERSION_10_10_2: u32 = 101002;
+pub const MAC_OS_X_VERSION_10_10_3: u32 = 101003;
+pub const MAC_OS_X_VERSION_10_11: u32 = 101100;
+pub const MAC_OS_X_VERSION_10_11_2: u32 = 101102;
+pub const MAC_OS_X_VERSION_10_11_3: u32 = 101103;
+pub const MAC_OS_X_VERSION_10_11_4: u32 = 101104;
+pub const MAC_OS_X_VERSION_10_12: u32 = 101200;
+pub const MAC_OS_X_VERSION_10_12_1: u32 = 101201;
+pub const MAC_OS_X_VERSION_10_12_2: u32 = 101202;
+pub const MAC_OS_X_VERSION_10_12_4: u32 = 101204;
+pub const MAC_OS_X_VERSION_10_13: u32 = 101300;
+pub const MAC_OS_X_VERSION_10_13_1: u32 = 101301;
+pub const MAC_OS_X_VERSION_10_13_2: u32 = 101302;
+pub const MAC_OS_X_VERSION_10_13_4: u32 = 101304;
+pub const MAC_OS_X_VERSION_10_14: u32 = 101400;
+pub const MAC_OS_X_VERSION_10_14_1: u32 = 101401;
+pub const MAC_OS_X_VERSION_10_14_4: u32 = 101404;
+pub const MAC_OS_X_VERSION_10_14_6: u32 = 101406;
+pub const MAC_OS_X_VERSION_10_15: u32 = 101500;
+pub const MAC_OS_X_VERSION_10_15_1: u32 = 101501;
+pub const MAC_OS_X_VERSION_10_16: u32 = 101600;
+pub const MAC_OS_VERSION_11_0: u32 = 110000;
 pub const __DRIVERKIT_19_0: u32 = 190000;
-pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 101500;
+pub const __DRIVERKIT_20_0: u32 = 200000;
+pub const __MAC_OS_X_VERSION_MAX_ALLOWED: u32 = 110100;
 pub const __ENABLE_LEGACY_MAC_AVAILABILITY: u32 = 1;
 pub const __DARWIN_ONLY_64_BIT_INO_T: u32 = 0;
-pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
 pub const __DARWIN_ONLY_UNIX_CONFORMANCE: u32 = 1;
+pub const __DARWIN_ONLY_VERS_1050: u32 = 0;
 pub const __DARWIN_UNIX03: u32 = 1;
 pub const __DARWIN_64_BIT_INO_T: u32 = 1;
 pub const __DARWIN_VERS_1050: u32 = 1;
@@ -263,6 +324,9 @@ pub const FP_RND_DOWN: u32 = 1;
 pub const FP_RND_UP: u32 = 2;
 pub const FP_CHOP: u32 = 3;
 pub const FP_STATE_BYTES: u32 = 512;
+pub const _X86_INSTRUCTION_STATE_MAX_INSN_BYTES: u32 = 2380;
+pub const _X86_INSTRUCTION_STATE_CACHELINE_SIZE: u32 = 64;
+pub const __LASTBRANCH_MAX: u32 = 32;
 pub const SIGEV_NONE: u32 = 0;
 pub const SIGEV_SIGNAL: u32 = 1;
 pub const SIGEV_THREAD: u32 = 3;
@@ -396,7 +460,9 @@ pub const RUSAGE_INFO_V1: u32 = 1;
 pub const RUSAGE_INFO_V2: u32 = 2;
 pub const RUSAGE_INFO_V3: u32 = 3;
 pub const RUSAGE_INFO_V4: u32 = 4;
-pub const RUSAGE_INFO_CURRENT: u32 = 4;
+pub const RUSAGE_INFO_V5: u32 = 5;
+pub const RUSAGE_INFO_CURRENT: u32 = 5;
+pub const RU_PROC_RUNS_RESLIDE: u32 = 1;
 pub const RLIMIT_CPU: u32 = 0;
 pub const RLIMIT_FSIZE: u32 = 1;
 pub const RLIMIT_DATA: u32 = 2;
@@ -424,6 +490,8 @@ pub const IOPOL_TYPE_DISK: u32 = 0;
 pub const IOPOL_TYPE_VFS_ATIME_UPDATES: u32 = 2;
 pub const IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES: u32 = 3;
 pub const IOPOL_TYPE_VFS_STATFS_NO_DATA_VOLUME: u32 = 4;
+pub const IOPOL_TYPE_VFS_TRIGGER_RESOLVE: u32 = 5;
+pub const IOPOL_TYPE_VFS_IGNORE_CONTENT_PROTECTION: u32 = 6;
 pub const IOPOL_SCOPE_PROCESS: u32 = 0;
 pub const IOPOL_SCOPE_THREAD: u32 = 1;
 pub const IOPOL_SCOPE_DARWIN_BG: u32 = 2;
@@ -442,6 +510,10 @@ pub const IOPOL_MATERIALIZE_DATALESS_FILES_OFF: u32 = 1;
 pub const IOPOL_MATERIALIZE_DATALESS_FILES_ON: u32 = 2;
 pub const IOPOL_VFS_STATFS_NO_DATA_VOLUME_DEFAULT: u32 = 0;
 pub const IOPOL_VFS_STATFS_FORCE_NO_DATA_VOLUME: u32 = 1;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_TRIGGER_RESOLVE_OFF: u32 = 1;
+pub const IOPOL_VFS_CONTENT_PROTECTION_DEFAULT: u32 = 0;
+pub const IOPOL_VFS_CONTENT_PROTECTION_IGNORE: u32 = 1;
 pub const WNOHANG: u32 = 1;
 pub const WUNTRACED: u32 = 2;
 pub const WCOREFLAG: u32 = 128;
@@ -3736,6 +3808,318 @@ fn bindgen_test_layout___darwin_x86_debug_state32() {
             stringify!(__dr7)
         )
     );
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct __x86_instruction_state {
+    pub __insn_stream_valid_bytes: ::std::os::raw::c_int,
+    pub __insn_offset: ::std::os::raw::c_int,
+    pub __out_of_synch: ::std::os::raw::c_int,
+    pub __insn_bytes: [__uint8_t; 2380usize],
+    pub __insn_cacheline: [__uint8_t; 64usize],
+}
+#[test]
+fn bindgen_test_layout___x86_instruction_state() {
+    assert_eq!(
+        ::std::mem::size_of::<__x86_instruction_state>(),
+        2456usize,
+        concat!("Size of: ", stringify!(__x86_instruction_state))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<__x86_instruction_state>(),
+        4usize,
+        concat!("Alignment of ", stringify!(__x86_instruction_state))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<__x86_instruction_state>())).__insn_stream_valid_bytes
+                as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__x86_instruction_state),
+            "::",
+            stringify!(__insn_stream_valid_bytes)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<__x86_instruction_state>())).__insn_offset as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__x86_instruction_state),
+            "::",
+            stringify!(__insn_offset)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<__x86_instruction_state>())).__out_of_synch as *const _ as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__x86_instruction_state),
+            "::",
+            stringify!(__out_of_synch)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<__x86_instruction_state>())).__insn_bytes as *const _ as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__x86_instruction_state),
+            "::",
+            stringify!(__insn_bytes)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<__x86_instruction_state>())).__insn_cacheline as *const _
+                as usize
+        },
+        2392usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__x86_instruction_state),
+            "::",
+            stringify!(__insn_cacheline)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __last_branch_record {
+    pub __from_ip: __uint64_t,
+    pub __to_ip: __uint64_t,
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u16>,
+    pub __bindgen_padding_0: u32,
+}
+#[test]
+fn bindgen_test_layout___last_branch_record() {
+    assert_eq!(
+        ::std::mem::size_of::<__last_branch_record>(),
+        24usize,
+        concat!("Size of: ", stringify!(__last_branch_record))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<__last_branch_record>(),
+        8usize,
+        concat!("Alignment of ", stringify!(__last_branch_record))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__last_branch_record>())).__from_ip as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__last_branch_record),
+            "::",
+            stringify!(__from_ip)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__last_branch_record>())).__to_ip as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__last_branch_record),
+            "::",
+            stringify!(__to_ip)
+        )
+    );
+}
+impl __last_branch_record {
+    #[inline]
+    pub fn __mispredict(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___mispredict(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __tsx_abort(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___tsx_abort(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __in_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___in_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(3usize, 16u8) as u32) }
+    }
+    #[inline]
+    pub fn set___cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(3usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(19usize, 13u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(19usize, 13u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __mispredict: __uint32_t,
+        __tsx_abort: __uint32_t,
+        __in_tsx: __uint32_t,
+        __cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize], u16> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize], u16> =
+            Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __mispredict: u32 = unsafe { ::std::mem::transmute(__mispredict) };
+            __mispredict as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __tsx_abort: u32 = unsafe { ::std::mem::transmute(__tsx_abort) };
+            __tsx_abort as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 1u8, {
+            let __in_tsx: u32 = unsafe { ::std::mem::transmute(__in_tsx) };
+            __in_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(3usize, 16u8, {
+            let __cycle_count: u32 = unsafe { ::std::mem::transmute(__cycle_count) };
+            __cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(19usize, 13u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __last_branch_state {
+    pub __lbr_count: ::std::os::raw::c_int,
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u32>,
+    pub __lbrs: [__last_branch_record; 32usize],
+}
+#[test]
+fn bindgen_test_layout___last_branch_state() {
+    assert_eq!(
+        ::std::mem::size_of::<__last_branch_state>(),
+        776usize,
+        concat!("Size of: ", stringify!(__last_branch_state))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<__last_branch_state>(),
+        8usize,
+        concat!("Alignment of ", stringify!(__last_branch_state))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__last_branch_state>())).__lbr_count as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__last_branch_state),
+            "::",
+            stringify!(__lbr_count)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__last_branch_state>())).__lbrs as *const _ as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__last_branch_state),
+            "::",
+            stringify!(__lbrs)
+        )
+    );
+}
+impl __last_branch_state {
+    #[inline]
+    pub fn __lbr_supported_tsx(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_tsx(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __lbr_supported_cycle_count(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set___lbr_supported_cycle_count(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn __reserved(&self) -> __uint32_t {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 30u8) as u32) }
+    }
+    #[inline]
+    pub fn set___reserved(&mut self, val: __uint32_t) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(2usize, 30u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        __lbr_supported_tsx: __uint32_t,
+        __lbr_supported_cycle_count: __uint32_t,
+        __reserved: __uint32_t,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize], u32> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize], u32> =
+            Default::default();
+        __bindgen_bitfield_unit.set(0usize, 1u8, {
+            let __lbr_supported_tsx: u32 = unsafe { ::std::mem::transmute(__lbr_supported_tsx) };
+            __lbr_supported_tsx as u64
+        });
+        __bindgen_bitfield_unit.set(1usize, 1u8, {
+            let __lbr_supported_cycle_count: u32 =
+                unsafe { ::std::mem::transmute(__lbr_supported_cycle_count) };
+            __lbr_supported_cycle_count as u64
+        });
+        __bindgen_bitfield_unit.set(2usize, 30u8, {
+            let __reserved: u32 = unsafe { ::std::mem::transmute(__reserved) };
+            __reserved as u64
+        });
+        __bindgen_bitfield_unit
+    }
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -7574,7 +7958,6 @@ fn bindgen_test_layout___darwin_ucontext() {
 }
 pub type ucontext_t = __darwin_ucontext;
 pub type sigset_t = __darwin_sigset_t;
-pub type size_t = __darwin_size_t;
 pub type uid_t = __darwin_uid_t;
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -9798,7 +10181,487 @@ fn bindgen_test_layout_rusage_info_v4() {
         )
     );
 }
-pub type rusage_info_current = rusage_info_v4;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rusage_info_v5 {
+    pub ri_uuid: [u8; 16usize],
+    pub ri_user_time: u64,
+    pub ri_system_time: u64,
+    pub ri_pkg_idle_wkups: u64,
+    pub ri_interrupt_wkups: u64,
+    pub ri_pageins: u64,
+    pub ri_wired_size: u64,
+    pub ri_resident_size: u64,
+    pub ri_phys_footprint: u64,
+    pub ri_proc_start_abstime: u64,
+    pub ri_proc_exit_abstime: u64,
+    pub ri_child_user_time: u64,
+    pub ri_child_system_time: u64,
+    pub ri_child_pkg_idle_wkups: u64,
+    pub ri_child_interrupt_wkups: u64,
+    pub ri_child_pageins: u64,
+    pub ri_child_elapsed_abstime: u64,
+    pub ri_diskio_bytesread: u64,
+    pub ri_diskio_byteswritten: u64,
+    pub ri_cpu_time_qos_default: u64,
+    pub ri_cpu_time_qos_maintenance: u64,
+    pub ri_cpu_time_qos_background: u64,
+    pub ri_cpu_time_qos_utility: u64,
+    pub ri_cpu_time_qos_legacy: u64,
+    pub ri_cpu_time_qos_user_initiated: u64,
+    pub ri_cpu_time_qos_user_interactive: u64,
+    pub ri_billed_system_time: u64,
+    pub ri_serviced_system_time: u64,
+    pub ri_logical_writes: u64,
+    pub ri_lifetime_max_phys_footprint: u64,
+    pub ri_instructions: u64,
+    pub ri_cycles: u64,
+    pub ri_billed_energy: u64,
+    pub ri_serviced_energy: u64,
+    pub ri_interval_max_phys_footprint: u64,
+    pub ri_runnable_time: u64,
+    pub ri_flags: u64,
+}
+#[test]
+fn bindgen_test_layout_rusage_info_v5() {
+    assert_eq!(
+        ::std::mem::size_of::<rusage_info_v5>(),
+        304usize,
+        concat!("Size of: ", stringify!(rusage_info_v5))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<rusage_info_v5>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rusage_info_v5))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_uuid as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_uuid)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_user_time as *const _ as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_user_time)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_system_time as *const _ as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_system_time)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_pkg_idle_wkups as *const _ as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_pkg_idle_wkups)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_interrupt_wkups as *const _ as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_interrupt_wkups)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_pageins as *const _ as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_pageins)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_wired_size as *const _ as usize },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_wired_size)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_resident_size as *const _ as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_resident_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_phys_footprint as *const _ as usize
+        },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_phys_footprint)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_proc_start_abstime as *const _ as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_proc_start_abstime)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_proc_exit_abstime as *const _ as usize
+        },
+        88usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_proc_exit_abstime)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_child_user_time as *const _ as usize
+        },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_child_user_time)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_child_system_time as *const _ as usize
+        },
+        104usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_child_system_time)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_child_pkg_idle_wkups as *const _ as usize
+        },
+        112usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_child_pkg_idle_wkups)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_child_interrupt_wkups as *const _ as usize
+        },
+        120usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_child_interrupt_wkups)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_child_pageins as *const _ as usize },
+        128usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_child_pageins)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_child_elapsed_abstime as *const _ as usize
+        },
+        136usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_child_elapsed_abstime)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_diskio_bytesread as *const _ as usize
+        },
+        144usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_diskio_bytesread)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_diskio_byteswritten as *const _ as usize
+        },
+        152usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_diskio_byteswritten)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_cpu_time_qos_default as *const _ as usize
+        },
+        160usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_cpu_time_qos_default)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_cpu_time_qos_maintenance as *const _
+                as usize
+        },
+        168usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_cpu_time_qos_maintenance)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_cpu_time_qos_background as *const _
+                as usize
+        },
+        176usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_cpu_time_qos_background)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_cpu_time_qos_utility as *const _ as usize
+        },
+        184usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_cpu_time_qos_utility)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_cpu_time_qos_legacy as *const _ as usize
+        },
+        192usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_cpu_time_qos_legacy)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_cpu_time_qos_user_initiated as *const _
+                as usize
+        },
+        200usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_cpu_time_qos_user_initiated)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_cpu_time_qos_user_interactive as *const _
+                as usize
+        },
+        208usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_cpu_time_qos_user_interactive)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_billed_system_time as *const _ as usize
+        },
+        216usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_billed_system_time)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_serviced_system_time as *const _ as usize
+        },
+        224usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_serviced_system_time)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_logical_writes as *const _ as usize
+        },
+        232usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_logical_writes)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_lifetime_max_phys_footprint as *const _
+                as usize
+        },
+        240usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_lifetime_max_phys_footprint)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_instructions as *const _ as usize },
+        248usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_instructions)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_cycles as *const _ as usize },
+        256usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_cycles)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_billed_energy as *const _ as usize },
+        264usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_billed_energy)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_serviced_energy as *const _ as usize
+        },
+        272usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_serviced_energy)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<rusage_info_v5>())).ri_interval_max_phys_footprint as *const _
+                as usize
+        },
+        280usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_interval_max_phys_footprint)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_runnable_time as *const _ as usize },
+        288usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_runnable_time)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<rusage_info_v5>())).ri_flags as *const _ as usize },
+        296usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rusage_info_v5),
+            "::",
+            stringify!(ri_flags)
+        )
+    );
+}
+pub type rusage_info_current = rusage_info_v5;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rlimit {
@@ -10300,16 +11163,16 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    pub fn valloc(arg1: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn valloc(arg1: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    pub fn aligned_alloc(__alignment: size_t, __size: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn aligned_alloc(__alignment: usize, __size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn posix_memalign(
         __memptr: *mut *mut ::std::os::raw::c_void,
-        __alignment: size_t,
-        __size: size_t,
+        __alignment: usize,
+        __size: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -10337,8 +11200,8 @@ extern "C" {
     pub fn bsearch(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *const ::std::os::raw::c_void,
@@ -10369,27 +11232,23 @@ extern "C" {
     pub fn lldiv(arg1: ::std::os::raw::c_longlong, arg2: ::std::os::raw::c_longlong) -> lldiv_t;
 }
 extern "C" {
-    pub fn mblen(__s: *const ::std::os::raw::c_char, __n: size_t) -> ::std::os::raw::c_int;
+    pub fn mblen(__s: *const ::std::os::raw::c_char, __n: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn mbstowcs(
-        arg1: *mut wchar_t,
-        arg2: *const ::std::os::raw::c_char,
-        arg3: size_t,
-    ) -> size_t;
+    pub fn mbstowcs(arg1: *mut wchar_t, arg2: *const ::std::os::raw::c_char, arg3: usize) -> usize;
 }
 extern "C" {
     pub fn mbtowc(
         arg1: *mut wchar_t,
         arg2: *const ::std::os::raw::c_char,
-        arg3: size_t,
+        arg3: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn qsort(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *const ::std::os::raw::c_void,
@@ -10454,11 +11313,7 @@ extern "C" {
     pub fn system(arg1: *const ::std::os::raw::c_char) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn wcstombs(
-        arg1: *mut ::std::os::raw::c_char,
-        arg2: *const wchar_t,
-        arg3: size_t,
-    ) -> size_t;
+    pub fn wcstombs(arg1: *mut ::std::os::raw::c_char, arg2: *const wchar_t, arg3: usize) -> usize;
 }
 extern "C" {
     pub fn wctomb(arg1: *mut ::std::os::raw::c_char, arg2: wchar_t) -> ::std::os::raw::c_int;
@@ -10512,7 +11367,7 @@ extern "C" {
     pub fn initstate(
         arg1: ::std::os::raw::c_uint,
         arg2: *mut ::std::os::raw::c_char,
-        arg3: size_t,
+        arg3: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -10549,7 +11404,7 @@ extern "C" {
     pub fn ptsname_r(
         fildes: ::std::os::raw::c_int,
         buffer: *mut ::std::os::raw::c_char,
-        buflen: size_t,
+        buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -10605,7 +11460,7 @@ extern "C" {
     pub fn arc4random_addrandom(arg1: *mut ::std::os::raw::c_uchar, arg2: ::std::os::raw::c_int);
 }
 extern "C" {
-    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: size_t);
+    pub fn arc4random_buf(__buf: *mut ::std::os::raw::c_void, __nbytes: usize);
 }
 extern "C" {
     pub fn arc4random_stir();
@@ -10620,8 +11475,8 @@ extern "C" {
     pub fn bsearch_b(
         __key: *const ::std::os::raw::c_void,
         __base: *const ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
 }
@@ -10720,8 +11575,8 @@ extern "C" {
 extern "C" {
     pub fn heapsort(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *const ::std::os::raw::c_void,
@@ -10733,16 +11588,16 @@ extern "C" {
 extern "C" {
     pub fn heapsort_b(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn mergesort(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *const ::std::os::raw::c_void,
@@ -10754,16 +11609,16 @@ extern "C" {
 extern "C" {
     pub fn mergesort_b(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn psort(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: *const ::std::os::raw::c_void,
@@ -10775,16 +11630,16 @@ extern "C" {
 extern "C" {
     pub fn psort_b(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
     pub fn psort_r(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         arg1: *mut ::std::os::raw::c_void,
         __compar: ::std::option::Option<
             unsafe extern "C" fn(
@@ -10798,16 +11653,16 @@ extern "C" {
 extern "C" {
     pub fn qsort_b(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         __compar: *mut ::std::os::raw::c_void,
     );
 }
 extern "C" {
     pub fn qsort_r(
         __base: *mut ::std::os::raw::c_void,
-        __nel: size_t,
-        __width: size_t,
+        __nel: usize,
+        __width: usize,
         arg1: *mut ::std::os::raw::c_void,
         __compar: ::std::option::Option<
             unsafe extern "C" fn(
@@ -10846,8 +11701,16 @@ extern "C" {
 extern "C" {
     pub fn reallocf(
         __ptr: *mut ::std::os::raw::c_void,
-        __size: size_t,
+        __size: usize,
     ) -> *mut ::std::os::raw::c_void;
+}
+extern "C" {
+    pub fn strtonum(
+        __numstr: *const ::std::os::raw::c_char,
+        __minval: ::std::os::raw::c_longlong,
+        __maxval: ::std::os::raw::c_longlong,
+        __errstrp: *mut *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_longlong;
 }
 extern "C" {
     pub fn strtoq(
@@ -11012,7 +11875,7 @@ extern "C" {
     pub fn strerror_r(
         __errnum: ::std::os::raw::c_int,
         __strerrbuf: *mut ::std::os::raw::c_char,
-        __buflen: size_t,
+        __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -11046,7 +11909,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: size_t) -> size_t;
+    pub fn strnlen(__s1: *const ::std::os::raw::c_char, __n: usize) -> usize;
 }
 extern "C" {
     pub fn strsignal(__sig: ::std::os::raw::c_int) -> *mut ::std::os::raw::c_char;
@@ -11061,34 +11924,33 @@ extern "C" {
         __n: rsize_t,
     ) -> errno_t;
 }
-pub type ssize_t = __darwin_ssize_t;
 extern "C" {
     pub fn memmem(
         __big: *const ::std::os::raw::c_void,
-        __big_len: size_t,
+        __big_len: usize,
         __little: *const ::std::os::raw::c_void,
-        __little_len: size_t,
+        __little_len: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn memset_pattern4(
         __b: *mut ::std::os::raw::c_void,
         __pattern4: *const ::std::os::raw::c_void,
-        __len: size_t,
+        __len: usize,
     );
 }
 extern "C" {
     pub fn memset_pattern8(
         __b: *mut ::std::os::raw::c_void,
         __pattern8: *const ::std::os::raw::c_void,
-        __len: size_t,
+        __len: usize,
     );
 }
 extern "C" {
     pub fn memset_pattern16(
         __b: *mut ::std::os::raw::c_void,
         __pattern16: *const ::std::os::raw::c_void,
-        __len: size_t,
+        __len: usize,
     );
 }
 extern "C" {
@@ -11101,7 +11963,7 @@ extern "C" {
     pub fn strnstr(
         __big: *const ::std::os::raw::c_char,
         __little: *const ::std::os::raw::c_char,
-        __len: size_t,
+        __len: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -11131,14 +11993,21 @@ extern "C" {
     pub fn swab(
         arg1: *const ::std::os::raw::c_void,
         arg2: *mut ::std::os::raw::c_void,
-        arg3: ssize_t,
+        arg3: isize,
     );
 }
 extern "C" {
     pub fn timingsafe_bcmp(
         __b1: *const ::std::os::raw::c_void,
         __b2: *const ::std::os::raw::c_void,
-        __len: size_t,
+        __len: usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn strsignal_r(
+        __sig: ::std::os::raw::c_int,
+        __strsignalbuf: *mut ::std::os::raw::c_char,
+        __buflen: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -11152,7 +12021,7 @@ extern "C" {
     pub fn bcopy(
         arg1: *const ::std::os::raw::c_void,
         arg2: *mut ::std::os::raw::c_void,
-        arg3: size_t,
+        arg3: usize,
     );
 }
 extern "C" {
@@ -11348,7 +12217,7 @@ pub type OrtStatusPtr = *mut OrtStatus;
 pub struct OrtAllocator {
     pub version: u32,
     pub Alloc: ::std::option::Option<
-        unsafe extern "C" fn(this_: *mut OrtAllocator, size: size_t) -> *mut ::std::os::raw::c_void,
+        unsafe extern "C" fn(this_: *mut OrtAllocator, size: usize) -> *mut ::std::os::raw::c_void,
     >,
     pub Free: ::std::option::Option<
         unsafe extern "C" fn(this_: *mut OrtAllocator, p: *mut ::std::os::raw::c_void),
@@ -11489,7 +12358,7 @@ pub enum OrtCudnnConvAlgoSearch {
 pub struct OrtCUDAProviderOptions {
     pub device_id: ::std::os::raw::c_int,
     pub cudnn_conv_algo_search: OrtCudnnConvAlgoSearch,
-    pub cuda_mem_limit: size_t,
+    pub cuda_mem_limit: usize,
     pub arena_extend_strategy: ::std::os::raw::c_int,
     pub do_copy_in_default_stream: ::std::os::raw::c_int,
 }
@@ -11578,7 +12447,7 @@ pub struct OrtOpenVINOProviderOptions {
     pub device_type: *const ::std::os::raw::c_char,
     pub enable_vpu_fast_compile: ::std::os::raw::c_uchar,
     pub device_id: *const ::std::os::raw::c_char,
-    pub num_of_threads: size_t,
+    pub num_of_threads: usize,
 }
 #[test]
 fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
@@ -11735,7 +12604,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             env: *const OrtEnv,
             model_data: *const ::std::os::raw::c_void,
-            model_data_length: size_t,
+            model_data_length: usize,
             options: *const OrtSessionOptions,
             out: *mut *mut OrtSession,
         ) -> OrtStatusPtr,
@@ -11746,9 +12615,9 @@ pub struct OrtApi {
             run_options: *const OrtRunOptions,
             input_names: *const *const ::std::os::raw::c_char,
             input: *const *const OrtValue,
-            input_len: size_t,
+            input_len: usize,
             output_names1: *const *const ::std::os::raw::c_char,
-            output_names_len: size_t,
+            output_names_len: usize,
             output: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -11856,39 +12725,39 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub SessionGetInputCount: ::std::option::Option<
-        unsafe extern "C" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetOutputCount: ::std::option::Option<
-        unsafe extern "C" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetOverridableInitializerCount: ::std::option::Option<
-        unsafe extern "C" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetInputTypeInfo: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetOutputTypeInfo: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetOverridableInitializerTypeInfo: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetInputName: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -11896,7 +12765,7 @@ pub struct OrtApi {
     pub SessionGetOutputName: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -11904,7 +12773,7 @@ pub struct OrtApi {
     pub SessionGetOverridableInitializerName: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -11955,7 +12824,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             allocator: *mut OrtAllocator,
             shape: *const i64,
-            shape_len: size_t,
+            shape_len: usize,
             type_: ONNXTensorElementDataType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -11964,9 +12833,9 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             info: *const OrtMemoryInfo,
             p_data: *mut ::std::os::raw::c_void,
-            p_data_len: size_t,
+            p_data_len: usize,
             shape: *const i64,
-            shape_len: size_t,
+            shape_len: usize,
             type_: ONNXTensorElementDataType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -11987,19 +12856,19 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             value: *mut OrtValue,
             s: *const *const ::std::os::raw::c_char,
-            s_len: size_t,
+            s_len: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetStringTensorDataLength: ::std::option::Option<
-        unsafe extern "C" fn(value: *const OrtValue, len: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(value: *const OrtValue, len: *mut usize) -> OrtStatusPtr,
     >,
     pub GetStringTensorContent: ::std::option::Option<
         unsafe extern "C" fn(
             value: *const OrtValue,
             s: *mut ::std::os::raw::c_void,
-            s_len: size_t,
-            offsets: *mut size_t,
-            offsets_len: size_t,
+            s_len: usize,
+            offsets: *mut usize,
+            offsets_len: usize,
         ) -> OrtStatusPtr,
     >,
     pub CastTypeInfoToTensorInfo: ::std::option::Option<
@@ -12024,7 +12893,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             info: *mut OrtTensorTypeAndShapeInfo,
             dim_values: *const i64,
-            dim_count: size_t,
+            dim_count: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorElementType: ::std::option::Option<
@@ -12036,27 +12905,27 @@ pub struct OrtApi {
     pub GetDimensionsCount: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetDimensions: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
             dim_values: *mut i64,
-            dim_values_length: size_t,
+            dim_values_length: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetSymbolicDimensions: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
             dim_params: *mut *const ::std::os::raw::c_char,
-            dim_params_length: size_t,
+            dim_params_length: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorShapeElementCount: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorTypeAndShape: ::std::option::Option<
@@ -12115,7 +12984,7 @@ pub struct OrtApi {
     pub AllocatorAlloc: ::std::option::Option<
         unsafe extern "C" fn(
             ptr: *mut OrtAllocator,
-            size: size_t,
+            size: usize,
             out: *mut *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -12149,12 +13018,12 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub GetValueCount: ::std::option::Option<
-        unsafe extern "C" fn(value: *const OrtValue, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(value: *const OrtValue, out: *mut usize) -> OrtStatusPtr,
     >,
     pub CreateValue: ::std::option::Option<
         unsafe extern "C" fn(
             in_: *const *const OrtValue,
-            num_values: size_t,
+            num_values: usize,
             value_type: ONNXType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -12164,7 +13033,7 @@ pub struct OrtApi {
             domain_name: *const ::std::os::raw::c_char,
             type_name: *const ::std::os::raw::c_char,
             data_container: *const ::std::os::raw::c_void,
-            data_container_size: size_t,
+            data_container_size: usize,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -12174,7 +13043,7 @@ pub struct OrtApi {
             type_name: *const ::std::os::raw::c_char,
             in_: *const OrtValue,
             data_container: *mut ::std::os::raw::c_void,
-            data_container_size: size_t,
+            data_container_size: usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelInfoGetAttribute_float: ::std::option::Option<
@@ -12196,28 +13065,28 @@ pub struct OrtApi {
             info: *const OrtKernelInfo,
             name: *const ::std::os::raw::c_char,
             out: *mut ::std::os::raw::c_char,
-            size: *mut size_t,
+            size: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetInputCount: ::std::option::Option<
-        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr,
     >,
     pub KernelContext_GetOutputCount: ::std::option::Option<
-        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr,
     >,
     pub KernelContext_GetInput: ::std::option::Option<
         unsafe extern "C" fn(
             context: *const OrtKernelContext,
-            index: size_t,
+            index: usize,
             out: *mut *const OrtValue,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetOutput: ::std::option::Option<
         unsafe extern "C" fn(
             context: *mut OrtKernelContext,
-            index: size_t,
+            index: usize,
             dim_values: *const i64,
-            dim_count: size_t,
+            dim_count: usize,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -12238,7 +13107,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             arg1: *const OrtTypeInfo,
             denotation: *mut *const ::std::os::raw::c_char,
-            len: *mut size_t,
+            len: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub CastTypeInfoToMapTypeInfo: ::std::option::Option<
@@ -12375,17 +13244,13 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub GetStringTensorElementLength: ::std::option::Option<
-        unsafe extern "C" fn(
-            value: *const OrtValue,
-            index: size_t,
-            out: *mut size_t,
-        ) -> OrtStatusPtr,
+        unsafe extern "C" fn(value: *const OrtValue, index: usize, out: *mut usize) -> OrtStatusPtr,
     >,
     pub GetStringTensorElement: ::std::option::Option<
         unsafe extern "C" fn(
             value: *const OrtValue,
-            s_len: size_t,
-            index: size_t,
+            s_len: usize,
+            index: usize,
             s: *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -12393,7 +13258,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             value: *mut OrtValue,
             s: *const ::std::os::raw::c_char,
-            index: size_t,
+            index: usize,
         ) -> OrtStatusPtr,
     >,
     pub AddSessionConfigEntry: ::std::option::Option<
@@ -12448,8 +13313,8 @@ pub struct OrtApi {
             binding_ptr: *const OrtIoBinding,
             allocator: *mut OrtAllocator,
             buffer: *mut *mut ::std::os::raw::c_char,
-            lengths: *mut *mut size_t,
-            count: *mut size_t,
+            lengths: *mut *mut usize,
+            count: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetBoundOutputValues: ::std::option::Option<
@@ -12457,7 +13322,7 @@ pub struct OrtApi {
             binding_ptr: *const OrtIoBinding,
             allocator: *mut OrtAllocator,
             output: *mut *mut *mut OrtValue,
-            output_count: *mut size_t,
+            output_count: *mut usize,
         ) -> OrtStatusPtr,
     >,
     #[doc = " Clears any previously specified bindings for inputs/outputs"]
@@ -12469,7 +13334,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             value: *mut OrtValue,
             location_values: *const i64,
-            location_values_count: size_t,
+            location_values_count: usize,
             out: *mut *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -12541,7 +13406,7 @@ pub struct OrtApi {
     >,
     pub CreateArenaCfg: ::std::option::Option<
         unsafe extern "C" fn(
-            max_mem: size_t,
+            max_mem: usize,
             arena_extend_strategy: ::std::os::raw::c_int,
             initial_chunk_size_bytes: ::std::os::raw::c_int,
             max_dead_bytes_per_chunk: ::std::os::raw::c_int,
@@ -14245,15 +15110,15 @@ pub struct OrtCustomOp {
         unsafe extern "C" fn(op: *const OrtCustomOp) -> *const ::std::os::raw::c_char,
     >,
     pub GetInputType: ::std::option::Option<
-        unsafe extern "C" fn(op: *const OrtCustomOp, index: size_t) -> ONNXTensorElementDataType,
+        unsafe extern "C" fn(op: *const OrtCustomOp, index: usize) -> ONNXTensorElementDataType,
     >,
     pub GetInputTypeCount:
-        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> size_t>,
+        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> usize>,
     pub GetOutputType: ::std::option::Option<
-        unsafe extern "C" fn(op: *const OrtCustomOp, index: size_t) -> ONNXTensorElementDataType,
+        unsafe extern "C" fn(op: *const OrtCustomOp, index: usize) -> ONNXTensorElementDataType,
     >,
     pub GetOutputTypeCount:
-        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> size_t>,
+        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> usize>,
     pub KernelCompute: ::std::option::Option<
         unsafe extern "C" fn(
             op_kernel: *mut ::std::os::raw::c_void,

--- a/onnxruntime-sys/src/generated/windows/x86/bindings.rs
+++ b/onnxruntime-sys/src/generated/windows/x86/bindings.rs
@@ -173,7 +173,6 @@ pub const __drv_typeCond: u32 = 1;
 pub const __drv_typeBitset: u32 = 2;
 pub const __drv_typeExpr: u32 = 3;
 pub type va_list = *mut ::std::os::raw::c_char;
-pub type size_t = ::std::os::raw::c_uint;
 pub type __vcrt_bool = bool;
 pub type wchar_t = ::std::os::raw::c_ushort;
 extern "C" {
@@ -359,9 +358,9 @@ fn bindgen_test_layout__Mbstatet() {
 }
 pub type mbstate_t = _Mbstatet;
 pub type time_t = __time64_t;
-pub type rsize_t = size_t;
+pub type rsize_t = usize;
 extern "C" {
-    pub fn _calloc_base(_Count: size_t, _Size: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn _calloc_base(_Count: usize, _Size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn calloc(
@@ -370,12 +369,12 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    pub fn _callnewh(_Size: size_t) -> ::std::os::raw::c_int;
+    pub fn _callnewh(_Size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _expand(
         _Block: *mut ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -385,21 +384,21 @@ extern "C" {
     pub fn free(_Block: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    pub fn _malloc_base(_Size: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn _malloc_base(_Size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn malloc(_Size: ::std::os::raw::c_uint) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    pub fn _msize_base(_Block: *mut ::std::os::raw::c_void) -> size_t;
+    pub fn _msize_base(_Block: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    pub fn _msize(_Block: *mut ::std::os::raw::c_void) -> size_t;
+    pub fn _msize(_Block: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
     pub fn _realloc_base(
         _Block: *mut ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -411,70 +410,84 @@ extern "C" {
 extern "C" {
     pub fn _recalloc_base(
         _Block: *mut ::std::os::raw::c_void,
-        _Count: size_t,
-        _Size: size_t,
+        _Count: usize,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _recalloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Count: size_t,
-        _Size: size_t,
+        _Count: usize,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_free(_Block: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    pub fn _aligned_malloc(_Size: size_t, _Alignment: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn _aligned_malloc(_Size: usize, _Alignment: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_offset_malloc(
-        _Size: size_t,
-        _Alignment: size_t,
-        _Offset: size_t,
+        _Size: usize,
+        _Alignment: usize,
+        _Offset: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_msize(
         _Block: *mut ::std::os::raw::c_void,
-        _Alignment: size_t,
-        _Offset: size_t,
-    ) -> size_t;
+        _Alignment: usize,
+        _Offset: usize,
+    ) -> usize;
 }
 extern "C" {
     pub fn _aligned_offset_realloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Size: size_t,
-        _Alignment: size_t,
-        _Offset: size_t,
+        _Size: usize,
+        _Alignment: usize,
+        _Offset: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_offset_recalloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Count: size_t,
-        _Size: size_t,
-        _Alignment: size_t,
-        _Offset: size_t,
+        _Count: usize,
+        _Size: usize,
+        _Alignment: usize,
+        _Offset: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_realloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Size: size_t,
-        _Alignment: size_t,
+        _Size: usize,
+        _Alignment: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_recalloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Count: size_t,
-        _Size: size_t,
-        _Alignment: size_t,
+        _Count: usize,
+        _Size: usize,
+        _Alignment: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
-pub type max_align_t = f64;
+extern "C" {
+    pub fn _errno() -> *mut ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn _set_errno(_Value: ::std::os::raw::c_int) -> errno_t;
+}
+extern "C" {
+    pub fn _get_errno(_Value: *mut ::std::os::raw::c_int) -> errno_t;
+}
+extern "C" {
+    pub fn __threadid() -> ::std::os::raw::c_ulong;
+}
+extern "C" {
+    pub fn __threadhandle() -> usize;
+}
 pub type _CoreCrtSecureSearchSortCompareFunction = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: *mut ::std::os::raw::c_void,
@@ -511,16 +524,16 @@ extern "C" {
     pub fn bsearch(
         _Key: *const ::std::os::raw::c_void,
         _Base: *const ::std::os::raw::c_void,
-        _NumOfElements: size_t,
-        _SizeOfElements: size_t,
+        _NumOfElements: usize,
+        _SizeOfElements: usize,
         _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn qsort(
         _Base: *mut ::std::os::raw::c_void,
-        _NumOfElements: size_t,
-        _SizeOfElements: size_t,
+        _NumOfElements: usize,
+        _SizeOfElements: usize,
         _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
     );
 }
@@ -529,7 +542,7 @@ extern "C" {
         _Key: *const ::std::os::raw::c_void,
         _Base: *const ::std::os::raw::c_void,
         _NumOfElements: *mut ::std::os::raw::c_uint,
-        _SizeOfElements: size_t,
+        _SizeOfElements: usize,
         _CompareFunction: _CoreCrtSecureSearchSortCompareFunction,
         _Context: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
@@ -548,7 +561,7 @@ extern "C" {
         _Key: *const ::std::os::raw::c_void,
         _Base: *mut ::std::os::raw::c_void,
         _NumOfElements: *mut ::std::os::raw::c_uint,
-        _SizeOfElements: size_t,
+        _SizeOfElements: usize,
         _CompareFunction: _CoreCrtSecureSearchSortCompareFunction,
         _Context: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
@@ -584,7 +597,7 @@ extern "C" {
     pub fn _itow_s(
         _Value: ::std::os::raw::c_int,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -599,7 +612,7 @@ extern "C" {
     pub fn _ltow_s(
         _Value: ::std::os::raw::c_long,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -614,7 +627,7 @@ extern "C" {
     pub fn _ultow_s(
         _Value: ::std::os::raw::c_ulong,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -743,7 +756,7 @@ extern "C" {
     pub fn _i64tow_s(
         _Value: ::std::os::raw::c_longlong,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -758,7 +771,7 @@ extern "C" {
     pub fn _ui64tow_s(
         _Value: ::std::os::raw::c_ulonglong,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -809,13 +822,13 @@ extern "C" {
     pub fn _wfullpath(
         _Buffer: *mut wchar_t,
         _Path: *const wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
     ) -> *mut wchar_t;
 }
 extern "C" {
     pub fn _wmakepath_s(
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Drive: *const wchar_t,
         _Dir: *const wchar_t,
         _Filename: *const wchar_t,
@@ -847,19 +860,19 @@ extern "C" {
     pub fn _wsplitpath_s(
         _FullPath: *const wchar_t,
         _Drive: *mut wchar_t,
-        _DriveCount: size_t,
+        _DriveCount: usize,
         _Dir: *mut wchar_t,
-        _DirCount: size_t,
+        _DirCount: usize,
         _Filename: *mut wchar_t,
-        _FilenameCount: size_t,
+        _FilenameCount: usize,
         _Ext: *mut wchar_t,
-        _ExtCount: size_t,
+        _ExtCount: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn _wdupenv_s(
         _Buffer: *mut *mut wchar_t,
-        _BufferCount: *mut size_t,
+        _BufferCount: *mut usize,
         _VarName: *const wchar_t,
     ) -> errno_t;
 }
@@ -868,9 +881,9 @@ extern "C" {
 }
 extern "C" {
     pub fn _wgetenv_s(
-        _RequiredCount: *mut size_t,
+        _RequiredCount: *mut usize,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _VarName: *const wchar_t,
     ) -> errno_t;
 }
@@ -885,7 +898,7 @@ extern "C" {
         _Filename: *const wchar_t,
         _VarName: *const wchar_t,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
     ) -> errno_t;
 }
 extern "C" {
@@ -972,15 +985,6 @@ extern "C" {
 }
 extern "C" {
     pub fn _set_error_mode(_Mode: ::std::os::raw::c_int) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn _errno() -> *mut ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn _set_errno(_Value: ::std::os::raw::c_int) -> errno_t;
-}
-extern "C" {
-    pub fn _get_errno(_Value: *mut ::std::os::raw::c_int) -> errno_t;
 }
 extern "C" {
     pub fn __doserrno() -> *mut ::std::os::raw::c_ulong;
@@ -1571,7 +1575,7 @@ extern "C" {
     pub fn _itoa_s(
         _Value: ::std::os::raw::c_int,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1586,7 +1590,7 @@ extern "C" {
     pub fn _ltoa_s(
         _Value: ::std::os::raw::c_long,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1601,7 +1605,7 @@ extern "C" {
     pub fn _ultoa_s(
         _Value: ::std::os::raw::c_ulong,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1616,7 +1620,7 @@ extern "C" {
     pub fn _i64toa_s(
         _Value: ::std::os::raw::c_longlong,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1631,7 +1635,7 @@ extern "C" {
     pub fn _ui64toa_s(
         _Value: ::std::os::raw::c_ulonglong,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1645,7 +1649,7 @@ extern "C" {
 extern "C" {
     pub fn _ecvt_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Value: f64,
         _DigitCount: ::std::os::raw::c_int,
         _PtDec: *mut ::std::os::raw::c_int,
@@ -1663,7 +1667,7 @@ extern "C" {
 extern "C" {
     pub fn _fcvt_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Value: f64,
         _FractionalDigitCount: ::std::os::raw::c_int,
         _PtDec: *mut ::std::os::raw::c_int,
@@ -1681,7 +1685,7 @@ extern "C" {
 extern "C" {
     pub fn _gcvt_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Value: f64,
         _DigitCount: ::std::os::raw::c_int,
     ) -> errno_t;
@@ -1700,69 +1704,69 @@ extern "C" {
     pub fn ___mb_cur_max_l_func(_Locale: _locale_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn mblen(_Ch: *const ::std::os::raw::c_char, _MaxCount: size_t) -> ::std::os::raw::c_int;
+    pub fn mblen(_Ch: *const ::std::os::raw::c_char, _MaxCount: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _mblen_l(
         _Ch: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn _mbstrlen(_String: *const ::std::os::raw::c_char) -> size_t;
+    pub fn _mbstrlen(_String: *const ::std::os::raw::c_char) -> usize;
 }
 extern "C" {
-    pub fn _mbstrlen_l(_String: *const ::std::os::raw::c_char, _Locale: _locale_t) -> size_t;
+    pub fn _mbstrlen_l(_String: *const ::std::os::raw::c_char, _Locale: _locale_t) -> usize;
 }
 extern "C" {
-    pub fn _mbstrnlen(_String: *const ::std::os::raw::c_char, _MaxCount: size_t) -> size_t;
+    pub fn _mbstrnlen(_String: *const ::std::os::raw::c_char, _MaxCount: usize) -> usize;
 }
 extern "C" {
     pub fn _mbstrnlen_l(
         _String: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn mbtowc(
         _DstCh: *mut wchar_t,
         _SrcCh: *const ::std::os::raw::c_char,
-        _SrcSizeInBytes: size_t,
+        _SrcSizeInBytes: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _mbtowc_l(
         _DstCh: *mut wchar_t,
         _SrcCh: *const ::std::os::raw::c_char,
-        _SrcSizeInBytes: size_t,
+        _SrcSizeInBytes: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn mbstowcs_s(
-        _PtNumOfCharConverted: *mut size_t,
+        _PtNumOfCharConverted: *mut usize,
         _DstBuf: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _SrcBuf: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn mbstowcs(
         _Dest: *mut wchar_t,
         _Source: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
-    ) -> size_t;
+        _MaxCount: usize,
+    ) -> usize;
 }
 extern "C" {
     pub fn _mbstowcs_s_l(
-        _PtNumOfCharConverted: *mut size_t,
+        _PtNumOfCharConverted: *mut usize,
         _DstBuf: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _SrcBuf: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> errno_t;
 }
@@ -1770,9 +1774,9 @@ extern "C" {
     pub fn _mbstowcs_l(
         _Dest: *mut wchar_t,
         _Source: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn wctomb(_MbCh: *mut ::std::os::raw::c_char, _WCh: wchar_t) -> ::std::os::raw::c_int;
@@ -1796,34 +1800,34 @@ extern "C" {
     pub fn _wctomb_s_l(
         _SizeConverted: *mut ::std::os::raw::c_int,
         _MbCh: *mut ::std::os::raw::c_char,
-        _SizeInBytes: size_t,
+        _SizeInBytes: usize,
         _WCh: wchar_t,
         _Locale: _locale_t,
     ) -> errno_t;
 }
 extern "C" {
     pub fn wcstombs_s(
-        _PtNumOfCharConverted: *mut size_t,
+        _PtNumOfCharConverted: *mut usize,
         _Dst: *mut ::std::os::raw::c_char,
-        _DstSizeInBytes: size_t,
+        _DstSizeInBytes: usize,
         _Src: *const wchar_t,
-        _MaxCountInBytes: size_t,
+        _MaxCountInBytes: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn wcstombs(
         _Dest: *mut ::std::os::raw::c_char,
         _Source: *const wchar_t,
-        _MaxCount: size_t,
-    ) -> size_t;
+        _MaxCount: usize,
+    ) -> usize;
 }
 extern "C" {
     pub fn _wcstombs_s_l(
-        _PtNumOfCharConverted: *mut size_t,
+        _PtNumOfCharConverted: *mut usize,
         _Dst: *mut ::std::os::raw::c_char,
-        _DstSizeInBytes: size_t,
+        _DstSizeInBytes: usize,
         _Src: *const wchar_t,
-        _MaxCountInBytes: size_t,
+        _MaxCountInBytes: usize,
         _Locale: _locale_t,
     ) -> errno_t;
 }
@@ -1831,21 +1835,21 @@ extern "C" {
     pub fn _wcstombs_l(
         _Dest: *mut ::std::os::raw::c_char,
         _Source: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn _fullpath(
         _Buffer: *mut ::std::os::raw::c_char,
         _Path: *const ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
     pub fn _makepath_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Drive: *const ::std::os::raw::c_char,
         _Dir: *const ::std::os::raw::c_char,
         _Filename: *const ::std::os::raw::c_char,
@@ -1874,18 +1878,18 @@ extern "C" {
     pub fn _splitpath_s(
         _FullPath: *const ::std::os::raw::c_char,
         _Drive: *mut ::std::os::raw::c_char,
-        _DriveCount: size_t,
+        _DriveCount: usize,
         _Dir: *mut ::std::os::raw::c_char,
-        _DirCount: size_t,
+        _DirCount: usize,
         _Filename: *mut ::std::os::raw::c_char,
-        _FilenameCount: size_t,
+        _FilenameCount: usize,
         _Ext: *mut ::std::os::raw::c_char,
-        _ExtCount: size_t,
+        _ExtCount: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn getenv_s(
-        _RequiredCount: *mut size_t,
+        _RequiredCount: *mut usize,
         _Buffer: *mut ::std::os::raw::c_char,
         _BufferCount: rsize_t,
         _VarName: *const ::std::os::raw::c_char,
@@ -1912,7 +1916,7 @@ extern "C" {
 extern "C" {
     pub fn _dupenv_s(
         _Buffer: *mut *mut ::std::os::raw::c_char,
-        _BufferCount: *mut size_t,
+        _BufferCount: *mut usize,
         _VarName: *const ::std::os::raw::c_char,
     ) -> errno_t;
 }
@@ -1933,7 +1937,7 @@ extern "C" {
         _Filename: *const ::std::os::raw::c_char,
         _VarName: *const ::std::os::raw::c_char,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
     ) -> errno_t;
 }
 extern "C" {
@@ -2096,14 +2100,14 @@ extern "C" {
     pub fn _memicmp(
         _Buf1: *const ::std::os::raw::c_void,
         _Buf2: *const ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _memicmp_l(
         _Buf1: *const ::std::os::raw::c_void,
         _Buf2: *const ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2119,7 +2123,7 @@ extern "C" {
     pub fn memicmp(
         _Buf1: *const ::std::os::raw::c_void,
         _Buf2: *const ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2175,19 +2179,19 @@ extern "C" {
     pub fn wcscpy(_Destination: *mut wchar_t, _Source: *const wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn wcscspn(_String: *const wchar_t, _Control: *const wchar_t) -> size_t;
+    pub fn wcscspn(_String: *const wchar_t, _Control: *const wchar_t) -> usize;
 }
 extern "C" {
     pub fn wcslen(_String: *const ::std::os::raw::c_ushort) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    pub fn wcsnlen(_Source: *const wchar_t, _MaxCount: size_t) -> size_t;
+    pub fn wcsnlen(_Source: *const wchar_t, _MaxCount: usize) -> usize;
 }
 extern "C" {
     pub fn wcsncat(
         _Destination: *mut wchar_t,
         _Source: *const wchar_t,
-        _Count: size_t,
+        _Count: usize,
     ) -> *mut wchar_t;
 }
 extern "C" {
@@ -2201,14 +2205,14 @@ extern "C" {
     pub fn wcsncpy(
         _Destination: *mut wchar_t,
         _Source: *const wchar_t,
-        _Count: size_t,
+        _Count: usize,
     ) -> *mut wchar_t;
 }
 extern "C" {
     pub fn wcspbrk(_String: *const wchar_t, _Control: *const wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn wcsspn(_String: *const wchar_t, _Control: *const wchar_t) -> size_t;
+    pub fn wcsspn(_String: *const wchar_t, _Control: *const wchar_t) -> usize;
 }
 extern "C" {
     pub fn wcstok(
@@ -2223,7 +2227,7 @@ extern "C" {
 extern "C" {
     pub fn _wcserror_s(
         _Buffer: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _ErrorNumber: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -2233,7 +2237,7 @@ extern "C" {
 extern "C" {
     pub fn __wcserror_s(
         _Buffer: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _ErrorMessage: *const wchar_t,
     ) -> errno_t;
 }
@@ -2251,75 +2255,71 @@ extern "C" {
     pub fn _wcsnicmp(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _wcsnicmp_l(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _wcsnset_s(
         _Destination: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _Value: wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> errno_t;
 }
 extern "C" {
-    pub fn _wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: size_t) -> *mut wchar_t;
+    pub fn _wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: usize) -> *mut wchar_t;
 }
 extern "C" {
     pub fn _wcsrev(_String: *mut wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcsset_s(_Destination: *mut wchar_t, _SizeInWords: size_t, _Value: wchar_t) -> errno_t;
+    pub fn _wcsset_s(_Destination: *mut wchar_t, _SizeInWords: usize, _Value: wchar_t) -> errno_t;
 }
 extern "C" {
     pub fn _wcsset(_String: *mut wchar_t, _Value: wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcslwr_s(_String: *mut wchar_t, _SizeInWords: size_t) -> errno_t;
+    pub fn _wcslwr_s(_String: *mut wchar_t, _SizeInWords: usize) -> errno_t;
 }
 extern "C" {
     pub fn _wcslwr(_String: *mut wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcslwr_s_l(_String: *mut wchar_t, _SizeInWords: size_t, _Locale: _locale_t) -> errno_t;
+    pub fn _wcslwr_s_l(_String: *mut wchar_t, _SizeInWords: usize, _Locale: _locale_t) -> errno_t;
 }
 extern "C" {
     pub fn _wcslwr_l(_String: *mut wchar_t, _Locale: _locale_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcsupr_s(_String: *mut wchar_t, _Size: size_t) -> errno_t;
+    pub fn _wcsupr_s(_String: *mut wchar_t, _Size: usize) -> errno_t;
 }
 extern "C" {
     pub fn _wcsupr(_String: *mut wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcsupr_s_l(_String: *mut wchar_t, _Size: size_t, _Locale: _locale_t) -> errno_t;
+    pub fn _wcsupr_s_l(_String: *mut wchar_t, _Size: usize, _Locale: _locale_t) -> errno_t;
 }
 extern "C" {
     pub fn _wcsupr_l(_String: *mut wchar_t, _Locale: _locale_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn wcsxfrm(
-        _Destination: *mut wchar_t,
-        _Source: *const wchar_t,
-        _MaxCount: size_t,
-    ) -> size_t;
+    pub fn wcsxfrm(_Destination: *mut wchar_t, _Source: *const wchar_t, _MaxCount: usize) -> usize;
 }
 extern "C" {
     pub fn _wcsxfrm_l(
         _Destination: *mut wchar_t,
         _Source: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn wcscoll(_String1: *const wchar_t, _String2: *const wchar_t) -> ::std::os::raw::c_int;
@@ -2345,14 +2345,14 @@ extern "C" {
     pub fn _wcsncoll(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _wcsncoll_l(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2360,14 +2360,14 @@ extern "C" {
     pub fn _wcsnicoll(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _wcsnicoll_l(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2381,11 +2381,11 @@ extern "C" {
     pub fn wcsnicmp(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: size_t) -> *mut wchar_t;
+    pub fn wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: usize) -> *mut wchar_t;
 }
 extern "C" {
     pub fn wcsrev(_String: *mut wchar_t) -> *mut wchar_t;
@@ -2419,7 +2419,7 @@ extern "C" {
 extern "C" {
     pub fn strerror_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _SizeInBytes: size_t,
+        _SizeInBytes: usize,
         _ErrorNumber: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -2451,7 +2451,7 @@ extern "C" {
         _Dst: *mut ::std::os::raw::c_void,
         _Src: *const ::std::os::raw::c_void,
         _Val: ::std::os::raw::c_int,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -2506,7 +2506,7 @@ extern "C" {
 extern "C" {
     pub fn _strerror_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _SizeInBytes: size_t,
+        _SizeInBytes: usize,
         _ErrorMessage: *const ::std::os::raw::c_char,
     ) -> errno_t;
 }
@@ -2543,7 +2543,7 @@ extern "C" {
     pub fn strlen(_Str: *const ::std::os::raw::c_char) -> ::std::os::raw::c_uint;
 }
 extern "C" {
-    pub fn _strlwr_s(_String: *mut ::std::os::raw::c_char, _Size: size_t) -> errno_t;
+    pub fn _strlwr_s(_String: *mut ::std::os::raw::c_char, _Size: usize) -> errno_t;
 }
 extern "C" {
     pub fn _strlwr(_String: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
@@ -2551,7 +2551,7 @@ extern "C" {
 extern "C" {
     pub fn _strlwr_s_l(
         _String: *mut ::std::os::raw::c_char,
-        _Size: size_t,
+        _Size: usize,
         _Locale: _locale_t,
     ) -> errno_t;
 }
@@ -2579,14 +2579,14 @@ extern "C" {
     pub fn _strnicmp(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _strnicmp_l(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2594,14 +2594,14 @@ extern "C" {
     pub fn _strnicoll(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _strnicoll_l(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2609,19 +2609,19 @@ extern "C" {
     pub fn _strncoll(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _strncoll_l(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn __strncnt(_String: *const ::std::os::raw::c_char, _Count: size_t) -> size_t;
+    pub fn __strncnt(_String: *const ::std::os::raw::c_char, _Count: usize) -> usize;
 }
 extern "C" {
     pub fn strncpy(
@@ -2631,21 +2631,21 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    pub fn strnlen(_String: *const ::std::os::raw::c_char, _MaxCount: size_t) -> size_t;
+    pub fn strnlen(_String: *const ::std::os::raw::c_char, _MaxCount: usize) -> usize;
 }
 extern "C" {
     pub fn _strnset_s(
         _String: *mut ::std::os::raw::c_char,
-        _SizeInBytes: size_t,
+        _SizeInBytes: usize,
         _Value: ::std::os::raw::c_int,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn _strnset(
         _Destination: *mut ::std::os::raw::c_char,
         _Value: ::std::os::raw::c_int,
-        _Count: size_t,
+        _Count: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2660,7 +2660,7 @@ extern "C" {
 extern "C" {
     pub fn _strset_s(
         _Destination: *mut ::std::os::raw::c_char,
-        _DestinationSize: size_t,
+        _DestinationSize: usize,
         _Value: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -2683,7 +2683,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    pub fn _strupr_s(_String: *mut ::std::os::raw::c_char, _Size: size_t) -> errno_t;
+    pub fn _strupr_s(_String: *mut ::std::os::raw::c_char, _Size: usize) -> errno_t;
 }
 extern "C" {
     pub fn _strupr(_String: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
@@ -2691,7 +2691,7 @@ extern "C" {
 extern "C" {
     pub fn _strupr_s_l(
         _String: *mut ::std::os::raw::c_char,
-        _Size: size_t,
+        _Size: usize,
         _Locale: _locale_t,
     ) -> errno_t;
 }
@@ -2712,9 +2712,9 @@ extern "C" {
     pub fn _strxfrm_l(
         _Destination: *mut ::std::os::raw::c_char,
         _Source: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn strdup(_String: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
@@ -2738,14 +2738,14 @@ extern "C" {
     pub fn strnicmp(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn strnset(
         _String: *mut ::std::os::raw::c_char,
         _Value: ::std::os::raw::c_int,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2909,7 +2909,7 @@ pub struct OrtAllocator {
     pub Alloc: ::std::option::Option<
         unsafe extern "stdcall" fn(
             this_: *mut OrtAllocator,
-            size: size_t,
+            size: usize,
         ) -> *mut ::std::os::raw::c_void,
     >,
     pub Free: ::std::option::Option<
@@ -3051,7 +3051,7 @@ pub enum OrtCudnnConvAlgoSearch {
 pub struct OrtCUDAProviderOptions {
     pub device_id: ::std::os::raw::c_int,
     pub cudnn_conv_algo_search: OrtCudnnConvAlgoSearch,
-    pub cuda_mem_limit: size_t,
+    pub cuda_mem_limit: usize,
     pub arena_extend_strategy: ::std::os::raw::c_int,
     pub do_copy_in_default_stream: ::std::os::raw::c_int,
 }
@@ -3140,7 +3140,7 @@ pub struct OrtOpenVINOProviderOptions {
     pub device_type: *const ::std::os::raw::c_char,
     pub enable_vpu_fast_compile: ::std::os::raw::c_uchar,
     pub device_id: *const ::std::os::raw::c_char,
-    pub num_of_threads: size_t,
+    pub num_of_threads: usize,
 }
 #[test]
 fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
@@ -3297,7 +3297,7 @@ pub struct OrtApi {
         unsafe extern "stdcall" fn(
             env: *const OrtEnv,
             model_data: *const ::std::os::raw::c_void,
-            model_data_length: size_t,
+            model_data_length: usize,
             options: *const OrtSessionOptions,
             out: *mut *mut OrtSession,
         ) -> OrtStatusPtr,
@@ -3308,9 +3308,9 @@ pub struct OrtApi {
             run_options: *const OrtRunOptions,
             input_names: *const *const ::std::os::raw::c_char,
             input: *const *const OrtValue,
-            input_len: size_t,
+            input_len: usize,
             output_names1: *const *const ::std::os::raw::c_char,
-            output_names_len: size_t,
+            output_names_len: usize,
             output: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -3418,39 +3418,39 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub SessionGetInputCount: ::std::option::Option<
-        unsafe extern "stdcall" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "stdcall" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetOutputCount: ::std::option::Option<
-        unsafe extern "stdcall" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "stdcall" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetOverridableInitializerCount: ::std::option::Option<
-        unsafe extern "stdcall" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "stdcall" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetInputTypeInfo: ::std::option::Option<
         unsafe extern "stdcall" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetOutputTypeInfo: ::std::option::Option<
         unsafe extern "stdcall" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetOverridableInitializerTypeInfo: ::std::option::Option<
         unsafe extern "stdcall" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetInputName: ::std::option::Option<
         unsafe extern "stdcall" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -3458,7 +3458,7 @@ pub struct OrtApi {
     pub SessionGetOutputName: ::std::option::Option<
         unsafe extern "stdcall" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -3466,7 +3466,7 @@ pub struct OrtApi {
     pub SessionGetOverridableInitializerName: ::std::option::Option<
         unsafe extern "stdcall" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -3520,7 +3520,7 @@ pub struct OrtApi {
         unsafe extern "stdcall" fn(
             allocator: *mut OrtAllocator,
             shape: *const i64,
-            shape_len: size_t,
+            shape_len: usize,
             type_: ONNXTensorElementDataType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -3529,9 +3529,9 @@ pub struct OrtApi {
         unsafe extern "stdcall" fn(
             info: *const OrtMemoryInfo,
             p_data: *mut ::std::os::raw::c_void,
-            p_data_len: size_t,
+            p_data_len: usize,
             shape: *const i64,
-            shape_len: size_t,
+            shape_len: usize,
             type_: ONNXTensorElementDataType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -3552,19 +3552,19 @@ pub struct OrtApi {
         unsafe extern "stdcall" fn(
             value: *mut OrtValue,
             s: *const *const ::std::os::raw::c_char,
-            s_len: size_t,
+            s_len: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetStringTensorDataLength: ::std::option::Option<
-        unsafe extern "stdcall" fn(value: *const OrtValue, len: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "stdcall" fn(value: *const OrtValue, len: *mut usize) -> OrtStatusPtr,
     >,
     pub GetStringTensorContent: ::std::option::Option<
         unsafe extern "stdcall" fn(
             value: *const OrtValue,
             s: *mut ::std::os::raw::c_void,
-            s_len: size_t,
-            offsets: *mut size_t,
-            offsets_len: size_t,
+            s_len: usize,
+            offsets: *mut usize,
+            offsets_len: usize,
         ) -> OrtStatusPtr,
     >,
     pub CastTypeInfoToTensorInfo: ::std::option::Option<
@@ -3589,7 +3589,7 @@ pub struct OrtApi {
         unsafe extern "stdcall" fn(
             info: *mut OrtTensorTypeAndShapeInfo,
             dim_values: *const i64,
-            dim_count: size_t,
+            dim_count: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorElementType: ::std::option::Option<
@@ -3601,27 +3601,27 @@ pub struct OrtApi {
     pub GetDimensionsCount: ::std::option::Option<
         unsafe extern "stdcall" fn(
             info: *const OrtTensorTypeAndShapeInfo,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetDimensions: ::std::option::Option<
         unsafe extern "stdcall" fn(
             info: *const OrtTensorTypeAndShapeInfo,
             dim_values: *mut i64,
-            dim_values_length: size_t,
+            dim_values_length: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetSymbolicDimensions: ::std::option::Option<
         unsafe extern "stdcall" fn(
             info: *const OrtTensorTypeAndShapeInfo,
             dim_params: *mut *const ::std::os::raw::c_char,
-            dim_params_length: size_t,
+            dim_params_length: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorShapeElementCount: ::std::option::Option<
         unsafe extern "stdcall" fn(
             info: *const OrtTensorTypeAndShapeInfo,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorTypeAndShape: ::std::option::Option<
@@ -3686,7 +3686,7 @@ pub struct OrtApi {
     pub AllocatorAlloc: ::std::option::Option<
         unsafe extern "stdcall" fn(
             ptr: *mut OrtAllocator,
-            size: size_t,
+            size: usize,
             out: *mut *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -3721,12 +3721,12 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub GetValueCount: ::std::option::Option<
-        unsafe extern "stdcall" fn(value: *const OrtValue, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "stdcall" fn(value: *const OrtValue, out: *mut usize) -> OrtStatusPtr,
     >,
     pub CreateValue: ::std::option::Option<
         unsafe extern "stdcall" fn(
             in_: *const *const OrtValue,
-            num_values: size_t,
+            num_values: usize,
             value_type: ONNXType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -3736,7 +3736,7 @@ pub struct OrtApi {
             domain_name: *const ::std::os::raw::c_char,
             type_name: *const ::std::os::raw::c_char,
             data_container: *const ::std::os::raw::c_void,
-            data_container_size: size_t,
+            data_container_size: usize,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -3746,7 +3746,7 @@ pub struct OrtApi {
             type_name: *const ::std::os::raw::c_char,
             in_: *const OrtValue,
             data_container: *mut ::std::os::raw::c_void,
-            data_container_size: size_t,
+            data_container_size: usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelInfoGetAttribute_float: ::std::option::Option<
@@ -3768,34 +3768,34 @@ pub struct OrtApi {
             info: *const OrtKernelInfo,
             name: *const ::std::os::raw::c_char,
             out: *mut ::std::os::raw::c_char,
-            size: *mut size_t,
+            size: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetInputCount: ::std::option::Option<
         unsafe extern "stdcall" fn(
             context: *const OrtKernelContext,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetOutputCount: ::std::option::Option<
         unsafe extern "stdcall" fn(
             context: *const OrtKernelContext,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetInput: ::std::option::Option<
         unsafe extern "stdcall" fn(
             context: *const OrtKernelContext,
-            index: size_t,
+            index: usize,
             out: *mut *const OrtValue,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetOutput: ::std::option::Option<
         unsafe extern "stdcall" fn(
             context: *mut OrtKernelContext,
-            index: size_t,
+            index: usize,
             dim_values: *const i64,
-            dim_count: size_t,
+            dim_count: usize,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -3818,7 +3818,7 @@ pub struct OrtApi {
         unsafe extern "stdcall" fn(
             arg1: *const OrtTypeInfo,
             denotation: *mut *const ::std::os::raw::c_char,
-            len: *mut size_t,
+            len: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub CastTypeInfoToMapTypeInfo: ::std::option::Option<
@@ -3958,15 +3958,15 @@ pub struct OrtApi {
     pub GetStringTensorElementLength: ::std::option::Option<
         unsafe extern "stdcall" fn(
             value: *const OrtValue,
-            index: size_t,
-            out: *mut size_t,
+            index: usize,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetStringTensorElement: ::std::option::Option<
         unsafe extern "stdcall" fn(
             value: *const OrtValue,
-            s_len: size_t,
-            index: size_t,
+            s_len: usize,
+            index: usize,
             s: *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -3974,7 +3974,7 @@ pub struct OrtApi {
         unsafe extern "stdcall" fn(
             value: *mut OrtValue,
             s: *const ::std::os::raw::c_char,
-            index: size_t,
+            index: usize,
         ) -> OrtStatusPtr,
     >,
     pub AddSessionConfigEntry: ::std::option::Option<
@@ -4034,8 +4034,8 @@ pub struct OrtApi {
             binding_ptr: *const OrtIoBinding,
             allocator: *mut OrtAllocator,
             buffer: *mut *mut ::std::os::raw::c_char,
-            lengths: *mut *mut size_t,
-            count: *mut size_t,
+            lengths: *mut *mut usize,
+            count: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetBoundOutputValues: ::std::option::Option<
@@ -4043,7 +4043,7 @@ pub struct OrtApi {
             binding_ptr: *const OrtIoBinding,
             allocator: *mut OrtAllocator,
             output: *mut *mut *mut OrtValue,
-            output_count: *mut size_t,
+            output_count: *mut usize,
         ) -> OrtStatusPtr,
     >,
     #[doc = " Clears any previously specified bindings for inputs/outputs"]
@@ -4055,7 +4055,7 @@ pub struct OrtApi {
         unsafe extern "stdcall" fn(
             value: *mut OrtValue,
             location_values: *const i64,
-            location_values_count: size_t,
+            location_values_count: usize,
             out: *mut *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -4127,7 +4127,7 @@ pub struct OrtApi {
     >,
     pub CreateArenaCfg: ::std::option::Option<
         unsafe extern "stdcall" fn(
-            max_mem: size_t,
+            max_mem: usize,
             arena_extend_strategy: ::std::os::raw::c_int,
             initial_chunk_size_bytes: ::std::os::raw::c_int,
             max_dead_bytes_per_chunk: ::std::os::raw::c_int,
@@ -5833,19 +5833,19 @@ pub struct OrtCustomOp {
     pub GetInputType: ::std::option::Option<
         unsafe extern "stdcall" fn(
             op: *const OrtCustomOp,
-            index: size_t,
+            index: usize,
         ) -> ONNXTensorElementDataType,
     >,
     pub GetInputTypeCount:
-        ::std::option::Option<unsafe extern "stdcall" fn(op: *const OrtCustomOp) -> size_t>,
+        ::std::option::Option<unsafe extern "stdcall" fn(op: *const OrtCustomOp) -> usize>,
     pub GetOutputType: ::std::option::Option<
         unsafe extern "stdcall" fn(
             op: *const OrtCustomOp,
-            index: size_t,
+            index: usize,
         ) -> ONNXTensorElementDataType,
     >,
     pub GetOutputTypeCount:
-        ::std::option::Option<unsafe extern "stdcall" fn(op: *const OrtCustomOp) -> size_t>,
+        ::std::option::Option<unsafe extern "stdcall" fn(op: *const OrtCustomOp) -> usize>,
     pub KernelCompute: ::std::option::Option<
         unsafe extern "stdcall" fn(
             op_kernel: *mut ::std::os::raw::c_void,

--- a/onnxruntime-sys/src/generated/windows/x86_64/bindings.rs
+++ b/onnxruntime-sys/src/generated/windows/x86_64/bindings.rs
@@ -176,7 +176,6 @@ pub type va_list = *mut ::std::os::raw::c_char;
 extern "C" {
     pub fn __va_start(arg1: *mut *mut ::std::os::raw::c_char, ...);
 }
-pub type size_t = ::std::os::raw::c_ulonglong;
 pub type __vcrt_bool = bool;
 pub type wchar_t = ::std::os::raw::c_ushort;
 extern "C" {
@@ -362,9 +361,9 @@ fn bindgen_test_layout__Mbstatet() {
 }
 pub type mbstate_t = _Mbstatet;
 pub type time_t = __time64_t;
-pub type rsize_t = size_t;
+pub type rsize_t = usize;
 extern "C" {
-    pub fn _calloc_base(_Count: size_t, _Size: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn _calloc_base(_Count: usize, _Size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn calloc(
@@ -373,12 +372,12 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    pub fn _callnewh(_Size: size_t) -> ::std::os::raw::c_int;
+    pub fn _callnewh(_Size: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _expand(
         _Block: *mut ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -388,21 +387,21 @@ extern "C" {
     pub fn free(_Block: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    pub fn _malloc_base(_Size: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn _malloc_base(_Size: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn malloc(_Size: ::std::os::raw::c_ulonglong) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
-    pub fn _msize_base(_Block: *mut ::std::os::raw::c_void) -> size_t;
+    pub fn _msize_base(_Block: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
-    pub fn _msize(_Block: *mut ::std::os::raw::c_void) -> size_t;
+    pub fn _msize(_Block: *mut ::std::os::raw::c_void) -> usize;
 }
 extern "C" {
     pub fn _realloc_base(
         _Block: *mut ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -414,67 +413,67 @@ extern "C" {
 extern "C" {
     pub fn _recalloc_base(
         _Block: *mut ::std::os::raw::c_void,
-        _Count: size_t,
-        _Size: size_t,
+        _Count: usize,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _recalloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Count: size_t,
-        _Size: size_t,
+        _Count: usize,
+        _Size: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_free(_Block: *mut ::std::os::raw::c_void);
 }
 extern "C" {
-    pub fn _aligned_malloc(_Size: size_t, _Alignment: size_t) -> *mut ::std::os::raw::c_void;
+    pub fn _aligned_malloc(_Size: usize, _Alignment: usize) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_offset_malloc(
-        _Size: size_t,
-        _Alignment: size_t,
-        _Offset: size_t,
+        _Size: usize,
+        _Alignment: usize,
+        _Offset: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_msize(
         _Block: *mut ::std::os::raw::c_void,
-        _Alignment: size_t,
-        _Offset: size_t,
-    ) -> size_t;
+        _Alignment: usize,
+        _Offset: usize,
+    ) -> usize;
 }
 extern "C" {
     pub fn _aligned_offset_realloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Size: size_t,
-        _Alignment: size_t,
-        _Offset: size_t,
+        _Size: usize,
+        _Alignment: usize,
+        _Offset: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_offset_recalloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Count: size_t,
-        _Size: size_t,
-        _Alignment: size_t,
-        _Offset: size_t,
+        _Count: usize,
+        _Size: usize,
+        _Alignment: usize,
+        _Offset: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_realloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Size: size_t,
-        _Alignment: size_t,
+        _Size: usize,
+        _Alignment: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn _aligned_recalloc(
         _Block: *mut ::std::os::raw::c_void,
-        _Count: size_t,
-        _Size: size_t,
-        _Alignment: size_t,
+        _Count: usize,
+        _Size: usize,
+        _Alignment: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 pub type max_align_t = f64;
@@ -514,16 +513,16 @@ extern "C" {
     pub fn bsearch(
         _Key: *const ::std::os::raw::c_void,
         _Base: *const ::std::os::raw::c_void,
-        _NumOfElements: size_t,
-        _SizeOfElements: size_t,
+        _NumOfElements: usize,
+        _SizeOfElements: usize,
         _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
     pub fn qsort(
         _Base: *mut ::std::os::raw::c_void,
-        _NumOfElements: size_t,
-        _SizeOfElements: size_t,
+        _NumOfElements: usize,
+        _SizeOfElements: usize,
         _CompareFunction: _CoreCrtNonSecureSearchSortCompareFunction,
     );
 }
@@ -532,7 +531,7 @@ extern "C" {
         _Key: *const ::std::os::raw::c_void,
         _Base: *const ::std::os::raw::c_void,
         _NumOfElements: *mut ::std::os::raw::c_uint,
-        _SizeOfElements: size_t,
+        _SizeOfElements: usize,
         _CompareFunction: _CoreCrtSecureSearchSortCompareFunction,
         _Context: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
@@ -551,7 +550,7 @@ extern "C" {
         _Key: *const ::std::os::raw::c_void,
         _Base: *mut ::std::os::raw::c_void,
         _NumOfElements: *mut ::std::os::raw::c_uint,
-        _SizeOfElements: size_t,
+        _SizeOfElements: usize,
         _CompareFunction: _CoreCrtSecureSearchSortCompareFunction,
         _Context: *mut ::std::os::raw::c_void,
     ) -> *mut ::std::os::raw::c_void;
@@ -587,7 +586,7 @@ extern "C" {
     pub fn _itow_s(
         _Value: ::std::os::raw::c_int,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -602,7 +601,7 @@ extern "C" {
     pub fn _ltow_s(
         _Value: ::std::os::raw::c_long,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -617,7 +616,7 @@ extern "C" {
     pub fn _ultow_s(
         _Value: ::std::os::raw::c_ulong,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -746,7 +745,7 @@ extern "C" {
     pub fn _i64tow_s(
         _Value: ::std::os::raw::c_longlong,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -761,7 +760,7 @@ extern "C" {
     pub fn _ui64tow_s(
         _Value: ::std::os::raw::c_ulonglong,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -812,13 +811,13 @@ extern "C" {
     pub fn _wfullpath(
         _Buffer: *mut wchar_t,
         _Path: *const wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
     ) -> *mut wchar_t;
 }
 extern "C" {
     pub fn _wmakepath_s(
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Drive: *const wchar_t,
         _Dir: *const wchar_t,
         _Filename: *const wchar_t,
@@ -850,19 +849,19 @@ extern "C" {
     pub fn _wsplitpath_s(
         _FullPath: *const wchar_t,
         _Drive: *mut wchar_t,
-        _DriveCount: size_t,
+        _DriveCount: usize,
         _Dir: *mut wchar_t,
-        _DirCount: size_t,
+        _DirCount: usize,
         _Filename: *mut wchar_t,
-        _FilenameCount: size_t,
+        _FilenameCount: usize,
         _Ext: *mut wchar_t,
-        _ExtCount: size_t,
+        _ExtCount: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn _wdupenv_s(
         _Buffer: *mut *mut wchar_t,
-        _BufferCount: *mut size_t,
+        _BufferCount: *mut usize,
         _VarName: *const wchar_t,
     ) -> errno_t;
 }
@@ -871,9 +870,9 @@ extern "C" {
 }
 extern "C" {
     pub fn _wgetenv_s(
-        _RequiredCount: *mut size_t,
+        _RequiredCount: *mut usize,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _VarName: *const wchar_t,
     ) -> errno_t;
 }
@@ -888,7 +887,7 @@ extern "C" {
         _Filename: *const wchar_t,
         _VarName: *const wchar_t,
         _Buffer: *mut wchar_t,
-        _BufferCount: size_t,
+        _BufferCount: usize,
     ) -> errno_t;
 }
 extern "C" {
@@ -1574,7 +1573,7 @@ extern "C" {
     pub fn _itoa_s(
         _Value: ::std::os::raw::c_int,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1589,7 +1588,7 @@ extern "C" {
     pub fn _ltoa_s(
         _Value: ::std::os::raw::c_long,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1604,7 +1603,7 @@ extern "C" {
     pub fn _ultoa_s(
         _Value: ::std::os::raw::c_ulong,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1619,7 +1618,7 @@ extern "C" {
     pub fn _i64toa_s(
         _Value: ::std::os::raw::c_longlong,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1634,7 +1633,7 @@ extern "C" {
     pub fn _ui64toa_s(
         _Value: ::std::os::raw::c_ulonglong,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Radix: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -1648,7 +1647,7 @@ extern "C" {
 extern "C" {
     pub fn _ecvt_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Value: f64,
         _DigitCount: ::std::os::raw::c_int,
         _PtDec: *mut ::std::os::raw::c_int,
@@ -1666,7 +1665,7 @@ extern "C" {
 extern "C" {
     pub fn _fcvt_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Value: f64,
         _FractionalDigitCount: ::std::os::raw::c_int,
         _PtDec: *mut ::std::os::raw::c_int,
@@ -1684,7 +1683,7 @@ extern "C" {
 extern "C" {
     pub fn _gcvt_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Value: f64,
         _DigitCount: ::std::os::raw::c_int,
     ) -> errno_t;
@@ -1703,69 +1702,69 @@ extern "C" {
     pub fn ___mb_cur_max_l_func(_Locale: _locale_t) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn mblen(_Ch: *const ::std::os::raw::c_char, _MaxCount: size_t) -> ::std::os::raw::c_int;
+    pub fn mblen(_Ch: *const ::std::os::raw::c_char, _MaxCount: usize) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _mblen_l(
         _Ch: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn _mbstrlen(_String: *const ::std::os::raw::c_char) -> size_t;
+    pub fn _mbstrlen(_String: *const ::std::os::raw::c_char) -> usize;
 }
 extern "C" {
-    pub fn _mbstrlen_l(_String: *const ::std::os::raw::c_char, _Locale: _locale_t) -> size_t;
+    pub fn _mbstrlen_l(_String: *const ::std::os::raw::c_char, _Locale: _locale_t) -> usize;
 }
 extern "C" {
-    pub fn _mbstrnlen(_String: *const ::std::os::raw::c_char, _MaxCount: size_t) -> size_t;
+    pub fn _mbstrnlen(_String: *const ::std::os::raw::c_char, _MaxCount: usize) -> usize;
 }
 extern "C" {
     pub fn _mbstrnlen_l(
         _String: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn mbtowc(
         _DstCh: *mut wchar_t,
         _SrcCh: *const ::std::os::raw::c_char,
-        _SrcSizeInBytes: size_t,
+        _SrcSizeInBytes: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _mbtowc_l(
         _DstCh: *mut wchar_t,
         _SrcCh: *const ::std::os::raw::c_char,
-        _SrcSizeInBytes: size_t,
+        _SrcSizeInBytes: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn mbstowcs_s(
-        _PtNumOfCharConverted: *mut size_t,
+        _PtNumOfCharConverted: *mut usize,
         _DstBuf: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _SrcBuf: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn mbstowcs(
         _Dest: *mut wchar_t,
         _Source: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
-    ) -> size_t;
+        _MaxCount: usize,
+    ) -> usize;
 }
 extern "C" {
     pub fn _mbstowcs_s_l(
-        _PtNumOfCharConverted: *mut size_t,
+        _PtNumOfCharConverted: *mut usize,
         _DstBuf: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _SrcBuf: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> errno_t;
 }
@@ -1773,9 +1772,9 @@ extern "C" {
     pub fn _mbstowcs_l(
         _Dest: *mut wchar_t,
         _Source: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn wctomb(_MbCh: *mut ::std::os::raw::c_char, _WCh: wchar_t) -> ::std::os::raw::c_int;
@@ -1799,34 +1798,34 @@ extern "C" {
     pub fn _wctomb_s_l(
         _SizeConverted: *mut ::std::os::raw::c_int,
         _MbCh: *mut ::std::os::raw::c_char,
-        _SizeInBytes: size_t,
+        _SizeInBytes: usize,
         _WCh: wchar_t,
         _Locale: _locale_t,
     ) -> errno_t;
 }
 extern "C" {
     pub fn wcstombs_s(
-        _PtNumOfCharConverted: *mut size_t,
+        _PtNumOfCharConverted: *mut usize,
         _Dst: *mut ::std::os::raw::c_char,
-        _DstSizeInBytes: size_t,
+        _DstSizeInBytes: usize,
         _Src: *const wchar_t,
-        _MaxCountInBytes: size_t,
+        _MaxCountInBytes: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn wcstombs(
         _Dest: *mut ::std::os::raw::c_char,
         _Source: *const wchar_t,
-        _MaxCount: size_t,
-    ) -> size_t;
+        _MaxCount: usize,
+    ) -> usize;
 }
 extern "C" {
     pub fn _wcstombs_s_l(
-        _PtNumOfCharConverted: *mut size_t,
+        _PtNumOfCharConverted: *mut usize,
         _Dst: *mut ::std::os::raw::c_char,
-        _DstSizeInBytes: size_t,
+        _DstSizeInBytes: usize,
         _Src: *const wchar_t,
-        _MaxCountInBytes: size_t,
+        _MaxCountInBytes: usize,
         _Locale: _locale_t,
     ) -> errno_t;
 }
@@ -1834,21 +1833,21 @@ extern "C" {
     pub fn _wcstombs_l(
         _Dest: *mut ::std::os::raw::c_char,
         _Source: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn _fullpath(
         _Buffer: *mut ::std::os::raw::c_char,
         _Path: *const ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
     pub fn _makepath_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
         _Drive: *const ::std::os::raw::c_char,
         _Dir: *const ::std::os::raw::c_char,
         _Filename: *const ::std::os::raw::c_char,
@@ -1877,18 +1876,18 @@ extern "C" {
     pub fn _splitpath_s(
         _FullPath: *const ::std::os::raw::c_char,
         _Drive: *mut ::std::os::raw::c_char,
-        _DriveCount: size_t,
+        _DriveCount: usize,
         _Dir: *mut ::std::os::raw::c_char,
-        _DirCount: size_t,
+        _DirCount: usize,
         _Filename: *mut ::std::os::raw::c_char,
-        _FilenameCount: size_t,
+        _FilenameCount: usize,
         _Ext: *mut ::std::os::raw::c_char,
-        _ExtCount: size_t,
+        _ExtCount: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn getenv_s(
-        _RequiredCount: *mut size_t,
+        _RequiredCount: *mut usize,
         _Buffer: *mut ::std::os::raw::c_char,
         _BufferCount: rsize_t,
         _VarName: *const ::std::os::raw::c_char,
@@ -1915,7 +1914,7 @@ extern "C" {
 extern "C" {
     pub fn _dupenv_s(
         _Buffer: *mut *mut ::std::os::raw::c_char,
-        _BufferCount: *mut size_t,
+        _BufferCount: *mut usize,
         _VarName: *const ::std::os::raw::c_char,
     ) -> errno_t;
 }
@@ -1936,7 +1935,7 @@ extern "C" {
         _Filename: *const ::std::os::raw::c_char,
         _VarName: *const ::std::os::raw::c_char,
         _Buffer: *mut ::std::os::raw::c_char,
-        _BufferCount: size_t,
+        _BufferCount: usize,
     ) -> errno_t;
 }
 extern "C" {
@@ -2099,14 +2098,14 @@ extern "C" {
     pub fn _memicmp(
         _Buf1: *const ::std::os::raw::c_void,
         _Buf2: *const ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _memicmp_l(
         _Buf1: *const ::std::os::raw::c_void,
         _Buf2: *const ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2122,7 +2121,7 @@ extern "C" {
     pub fn memicmp(
         _Buf1: *const ::std::os::raw::c_void,
         _Buf2: *const ::std::os::raw::c_void,
-        _Size: size_t,
+        _Size: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
@@ -2178,19 +2177,19 @@ extern "C" {
     pub fn wcscpy(_Destination: *mut wchar_t, _Source: *const wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn wcscspn(_String: *const wchar_t, _Control: *const wchar_t) -> size_t;
+    pub fn wcscspn(_String: *const wchar_t, _Control: *const wchar_t) -> usize;
 }
 extern "C" {
     pub fn wcslen(_String: *const ::std::os::raw::c_ushort) -> ::std::os::raw::c_ulonglong;
 }
 extern "C" {
-    pub fn wcsnlen(_Source: *const wchar_t, _MaxCount: size_t) -> size_t;
+    pub fn wcsnlen(_Source: *const wchar_t, _MaxCount: usize) -> usize;
 }
 extern "C" {
     pub fn wcsncat(
         _Destination: *mut wchar_t,
         _Source: *const wchar_t,
-        _Count: size_t,
+        _Count: usize,
     ) -> *mut wchar_t;
 }
 extern "C" {
@@ -2204,14 +2203,14 @@ extern "C" {
     pub fn wcsncpy(
         _Destination: *mut wchar_t,
         _Source: *const wchar_t,
-        _Count: size_t,
+        _Count: usize,
     ) -> *mut wchar_t;
 }
 extern "C" {
     pub fn wcspbrk(_String: *const wchar_t, _Control: *const wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn wcsspn(_String: *const wchar_t, _Control: *const wchar_t) -> size_t;
+    pub fn wcsspn(_String: *const wchar_t, _Control: *const wchar_t) -> usize;
 }
 extern "C" {
     pub fn wcstok(
@@ -2226,7 +2225,7 @@ extern "C" {
 extern "C" {
     pub fn _wcserror_s(
         _Buffer: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _ErrorNumber: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -2236,7 +2235,7 @@ extern "C" {
 extern "C" {
     pub fn __wcserror_s(
         _Buffer: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _ErrorMessage: *const wchar_t,
     ) -> errno_t;
 }
@@ -2254,75 +2253,71 @@ extern "C" {
     pub fn _wcsnicmp(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _wcsnicmp_l(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _wcsnset_s(
         _Destination: *mut wchar_t,
-        _SizeInWords: size_t,
+        _SizeInWords: usize,
         _Value: wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> errno_t;
 }
 extern "C" {
-    pub fn _wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: size_t) -> *mut wchar_t;
+    pub fn _wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: usize) -> *mut wchar_t;
 }
 extern "C" {
     pub fn _wcsrev(_String: *mut wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcsset_s(_Destination: *mut wchar_t, _SizeInWords: size_t, _Value: wchar_t) -> errno_t;
+    pub fn _wcsset_s(_Destination: *mut wchar_t, _SizeInWords: usize, _Value: wchar_t) -> errno_t;
 }
 extern "C" {
     pub fn _wcsset(_String: *mut wchar_t, _Value: wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcslwr_s(_String: *mut wchar_t, _SizeInWords: size_t) -> errno_t;
+    pub fn _wcslwr_s(_String: *mut wchar_t, _SizeInWords: usize) -> errno_t;
 }
 extern "C" {
     pub fn _wcslwr(_String: *mut wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcslwr_s_l(_String: *mut wchar_t, _SizeInWords: size_t, _Locale: _locale_t) -> errno_t;
+    pub fn _wcslwr_s_l(_String: *mut wchar_t, _SizeInWords: usize, _Locale: _locale_t) -> errno_t;
 }
 extern "C" {
     pub fn _wcslwr_l(_String: *mut wchar_t, _Locale: _locale_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcsupr_s(_String: *mut wchar_t, _Size: size_t) -> errno_t;
+    pub fn _wcsupr_s(_String: *mut wchar_t, _Size: usize) -> errno_t;
 }
 extern "C" {
     pub fn _wcsupr(_String: *mut wchar_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn _wcsupr_s_l(_String: *mut wchar_t, _Size: size_t, _Locale: _locale_t) -> errno_t;
+    pub fn _wcsupr_s_l(_String: *mut wchar_t, _Size: usize, _Locale: _locale_t) -> errno_t;
 }
 extern "C" {
     pub fn _wcsupr_l(_String: *mut wchar_t, _Locale: _locale_t) -> *mut wchar_t;
 }
 extern "C" {
-    pub fn wcsxfrm(
-        _Destination: *mut wchar_t,
-        _Source: *const wchar_t,
-        _MaxCount: size_t,
-    ) -> size_t;
+    pub fn wcsxfrm(_Destination: *mut wchar_t, _Source: *const wchar_t, _MaxCount: usize) -> usize;
 }
 extern "C" {
     pub fn _wcsxfrm_l(
         _Destination: *mut wchar_t,
         _Source: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn wcscoll(_String1: *const wchar_t, _String2: *const wchar_t) -> ::std::os::raw::c_int;
@@ -2348,14 +2343,14 @@ extern "C" {
     pub fn _wcsncoll(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _wcsncoll_l(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2363,14 +2358,14 @@ extern "C" {
     pub fn _wcsnicoll(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _wcsnicoll_l(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2384,11 +2379,11 @@ extern "C" {
     pub fn wcsnicmp(
         _String1: *const wchar_t,
         _String2: *const wchar_t,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: size_t) -> *mut wchar_t;
+    pub fn wcsnset(_String: *mut wchar_t, _Value: wchar_t, _MaxCount: usize) -> *mut wchar_t;
 }
 extern "C" {
     pub fn wcsrev(_String: *mut wchar_t) -> *mut wchar_t;
@@ -2422,7 +2417,7 @@ extern "C" {
 extern "C" {
     pub fn strerror_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _SizeInBytes: size_t,
+        _SizeInBytes: usize,
         _ErrorNumber: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -2454,7 +2449,7 @@ extern "C" {
         _Dst: *mut ::std::os::raw::c_void,
         _Src: *const ::std::os::raw::c_void,
         _Val: ::std::os::raw::c_int,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> *mut ::std::os::raw::c_void;
 }
 extern "C" {
@@ -2509,7 +2504,7 @@ extern "C" {
 extern "C" {
     pub fn _strerror_s(
         _Buffer: *mut ::std::os::raw::c_char,
-        _SizeInBytes: size_t,
+        _SizeInBytes: usize,
         _ErrorMessage: *const ::std::os::raw::c_char,
     ) -> errno_t;
 }
@@ -2546,7 +2541,7 @@ extern "C" {
     pub fn strlen(_Str: *const ::std::os::raw::c_char) -> ::std::os::raw::c_ulonglong;
 }
 extern "C" {
-    pub fn _strlwr_s(_String: *mut ::std::os::raw::c_char, _Size: size_t) -> errno_t;
+    pub fn _strlwr_s(_String: *mut ::std::os::raw::c_char, _Size: usize) -> errno_t;
 }
 extern "C" {
     pub fn _strlwr(_String: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
@@ -2554,7 +2549,7 @@ extern "C" {
 extern "C" {
     pub fn _strlwr_s_l(
         _String: *mut ::std::os::raw::c_char,
-        _Size: size_t,
+        _Size: usize,
         _Locale: _locale_t,
     ) -> errno_t;
 }
@@ -2582,14 +2577,14 @@ extern "C" {
     pub fn _strnicmp(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _strnicmp_l(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2597,14 +2592,14 @@ extern "C" {
     pub fn _strnicoll(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _strnicoll_l(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
@@ -2612,19 +2607,19 @@ extern "C" {
     pub fn _strncoll(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn _strncoll_l(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
-    pub fn __strncnt(_String: *const ::std::os::raw::c_char, _Count: size_t) -> size_t;
+    pub fn __strncnt(_String: *const ::std::os::raw::c_char, _Count: usize) -> usize;
 }
 extern "C" {
     pub fn strncpy(
@@ -2634,21 +2629,21 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    pub fn strnlen(_String: *const ::std::os::raw::c_char, _MaxCount: size_t) -> size_t;
+    pub fn strnlen(_String: *const ::std::os::raw::c_char, _MaxCount: usize) -> usize;
 }
 extern "C" {
     pub fn _strnset_s(
         _String: *mut ::std::os::raw::c_char,
-        _SizeInBytes: size_t,
+        _SizeInBytes: usize,
         _Value: ::std::os::raw::c_int,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> errno_t;
 }
 extern "C" {
     pub fn _strnset(
         _Destination: *mut ::std::os::raw::c_char,
         _Value: ::std::os::raw::c_int,
-        _Count: size_t,
+        _Count: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2663,7 +2658,7 @@ extern "C" {
 extern "C" {
     pub fn _strset_s(
         _Destination: *mut ::std::os::raw::c_char,
-        _DestinationSize: size_t,
+        _DestinationSize: usize,
         _Value: ::std::os::raw::c_int,
     ) -> errno_t;
 }
@@ -2686,7 +2681,7 @@ extern "C" {
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
-    pub fn _strupr_s(_String: *mut ::std::os::raw::c_char, _Size: size_t) -> errno_t;
+    pub fn _strupr_s(_String: *mut ::std::os::raw::c_char, _Size: usize) -> errno_t;
 }
 extern "C" {
     pub fn _strupr(_String: *mut ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
@@ -2694,7 +2689,7 @@ extern "C" {
 extern "C" {
     pub fn _strupr_s_l(
         _String: *mut ::std::os::raw::c_char,
-        _Size: size_t,
+        _Size: usize,
         _Locale: _locale_t,
     ) -> errno_t;
 }
@@ -2715,9 +2710,9 @@ extern "C" {
     pub fn _strxfrm_l(
         _Destination: *mut ::std::os::raw::c_char,
         _Source: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
         _Locale: _locale_t,
-    ) -> size_t;
+    ) -> usize;
 }
 extern "C" {
     pub fn strdup(_String: *const ::std::os::raw::c_char) -> *mut ::std::os::raw::c_char;
@@ -2741,14 +2736,14 @@ extern "C" {
     pub fn strnicmp(
         _String1: *const ::std::os::raw::c_char,
         _String2: *const ::std::os::raw::c_char,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn strnset(
         _String: *mut ::std::os::raw::c_char,
         _Value: ::std::os::raw::c_int,
-        _MaxCount: size_t,
+        _MaxCount: usize,
     ) -> *mut ::std::os::raw::c_char;
 }
 extern "C" {
@@ -2910,7 +2905,7 @@ pub type OrtStatusPtr = *mut OrtStatus;
 pub struct OrtAllocator {
     pub version: u32,
     pub Alloc: ::std::option::Option<
-        unsafe extern "C" fn(this_: *mut OrtAllocator, size: size_t) -> *mut ::std::os::raw::c_void,
+        unsafe extern "C" fn(this_: *mut OrtAllocator, size: usize) -> *mut ::std::os::raw::c_void,
     >,
     pub Free: ::std::option::Option<
         unsafe extern "C" fn(this_: *mut OrtAllocator, p: *mut ::std::os::raw::c_void),
@@ -3051,7 +3046,7 @@ pub enum OrtCudnnConvAlgoSearch {
 pub struct OrtCUDAProviderOptions {
     pub device_id: ::std::os::raw::c_int,
     pub cudnn_conv_algo_search: OrtCudnnConvAlgoSearch,
-    pub cuda_mem_limit: size_t,
+    pub cuda_mem_limit: usize,
     pub arena_extend_strategy: ::std::os::raw::c_int,
     pub do_copy_in_default_stream: ::std::os::raw::c_int,
 }
@@ -3140,7 +3135,7 @@ pub struct OrtOpenVINOProviderOptions {
     pub device_type: *const ::std::os::raw::c_char,
     pub enable_vpu_fast_compile: ::std::os::raw::c_uchar,
     pub device_id: *const ::std::os::raw::c_char,
-    pub num_of_threads: size_t,
+    pub num_of_threads: usize,
 }
 #[test]
 fn bindgen_test_layout_OrtOpenVINOProviderOptions() {
@@ -3297,7 +3292,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             env: *const OrtEnv,
             model_data: *const ::std::os::raw::c_void,
-            model_data_length: size_t,
+            model_data_length: usize,
             options: *const OrtSessionOptions,
             out: *mut *mut OrtSession,
         ) -> OrtStatusPtr,
@@ -3308,9 +3303,9 @@ pub struct OrtApi {
             run_options: *const OrtRunOptions,
             input_names: *const *const ::std::os::raw::c_char,
             input: *const *const OrtValue,
-            input_len: size_t,
+            input_len: usize,
             output_names1: *const *const ::std::os::raw::c_char,
-            output_names_len: size_t,
+            output_names_len: usize,
             output: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -3418,39 +3413,39 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub SessionGetInputCount: ::std::option::Option<
-        unsafe extern "C" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetOutputCount: ::std::option::Option<
-        unsafe extern "C" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetOverridableInitializerCount: ::std::option::Option<
-        unsafe extern "C" fn(sess: *const OrtSession, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(sess: *const OrtSession, out: *mut usize) -> OrtStatusPtr,
     >,
     pub SessionGetInputTypeInfo: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetOutputTypeInfo: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetOverridableInitializerTypeInfo: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             type_info: *mut *mut OrtTypeInfo,
         ) -> OrtStatusPtr,
     >,
     pub SessionGetInputName: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -3458,7 +3453,7 @@ pub struct OrtApi {
     pub SessionGetOutputName: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -3466,7 +3461,7 @@ pub struct OrtApi {
     pub SessionGetOverridableInitializerName: ::std::option::Option<
         unsafe extern "C" fn(
             sess: *const OrtSession,
-            index: size_t,
+            index: usize,
             allocator: *mut OrtAllocator,
             value: *mut *mut ::std::os::raw::c_char,
         ) -> OrtStatusPtr,
@@ -3517,7 +3512,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             allocator: *mut OrtAllocator,
             shape: *const i64,
-            shape_len: size_t,
+            shape_len: usize,
             type_: ONNXTensorElementDataType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -3526,9 +3521,9 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             info: *const OrtMemoryInfo,
             p_data: *mut ::std::os::raw::c_void,
-            p_data_len: size_t,
+            p_data_len: usize,
             shape: *const i64,
-            shape_len: size_t,
+            shape_len: usize,
             type_: ONNXTensorElementDataType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -3549,19 +3544,19 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             value: *mut OrtValue,
             s: *const *const ::std::os::raw::c_char,
-            s_len: size_t,
+            s_len: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetStringTensorDataLength: ::std::option::Option<
-        unsafe extern "C" fn(value: *const OrtValue, len: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(value: *const OrtValue, len: *mut usize) -> OrtStatusPtr,
     >,
     pub GetStringTensorContent: ::std::option::Option<
         unsafe extern "C" fn(
             value: *const OrtValue,
             s: *mut ::std::os::raw::c_void,
-            s_len: size_t,
-            offsets: *mut size_t,
-            offsets_len: size_t,
+            s_len: usize,
+            offsets: *mut usize,
+            offsets_len: usize,
         ) -> OrtStatusPtr,
     >,
     pub CastTypeInfoToTensorInfo: ::std::option::Option<
@@ -3586,7 +3581,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             info: *mut OrtTensorTypeAndShapeInfo,
             dim_values: *const i64,
-            dim_count: size_t,
+            dim_count: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorElementType: ::std::option::Option<
@@ -3598,27 +3593,27 @@ pub struct OrtApi {
     pub GetDimensionsCount: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetDimensions: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
             dim_values: *mut i64,
-            dim_values_length: size_t,
+            dim_values_length: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetSymbolicDimensions: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
             dim_params: *mut *const ::std::os::raw::c_char,
-            dim_params_length: size_t,
+            dim_params_length: usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorShapeElementCount: ::std::option::Option<
         unsafe extern "C" fn(
             info: *const OrtTensorTypeAndShapeInfo,
-            out: *mut size_t,
+            out: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetTensorTypeAndShape: ::std::option::Option<
@@ -3677,7 +3672,7 @@ pub struct OrtApi {
     pub AllocatorAlloc: ::std::option::Option<
         unsafe extern "C" fn(
             ptr: *mut OrtAllocator,
-            size: size_t,
+            size: usize,
             out: *mut *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -3711,12 +3706,12 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub GetValueCount: ::std::option::Option<
-        unsafe extern "C" fn(value: *const OrtValue, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(value: *const OrtValue, out: *mut usize) -> OrtStatusPtr,
     >,
     pub CreateValue: ::std::option::Option<
         unsafe extern "C" fn(
             in_: *const *const OrtValue,
-            num_values: size_t,
+            num_values: usize,
             value_type: ONNXType,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
@@ -3726,7 +3721,7 @@ pub struct OrtApi {
             domain_name: *const ::std::os::raw::c_char,
             type_name: *const ::std::os::raw::c_char,
             data_container: *const ::std::os::raw::c_void,
-            data_container_size: size_t,
+            data_container_size: usize,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -3736,7 +3731,7 @@ pub struct OrtApi {
             type_name: *const ::std::os::raw::c_char,
             in_: *const OrtValue,
             data_container: *mut ::std::os::raw::c_void,
-            data_container_size: size_t,
+            data_container_size: usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelInfoGetAttribute_float: ::std::option::Option<
@@ -3758,28 +3753,28 @@ pub struct OrtApi {
             info: *const OrtKernelInfo,
             name: *const ::std::os::raw::c_char,
             out: *mut ::std::os::raw::c_char,
-            size: *mut size_t,
+            size: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetInputCount: ::std::option::Option<
-        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr,
     >,
     pub KernelContext_GetOutputCount: ::std::option::Option<
-        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut size_t) -> OrtStatusPtr,
+        unsafe extern "C" fn(context: *const OrtKernelContext, out: *mut usize) -> OrtStatusPtr,
     >,
     pub KernelContext_GetInput: ::std::option::Option<
         unsafe extern "C" fn(
             context: *const OrtKernelContext,
-            index: size_t,
+            index: usize,
             out: *mut *const OrtValue,
         ) -> OrtStatusPtr,
     >,
     pub KernelContext_GetOutput: ::std::option::Option<
         unsafe extern "C" fn(
             context: *mut OrtKernelContext,
-            index: size_t,
+            index: usize,
             dim_values: *const i64,
-            dim_count: size_t,
+            dim_count: usize,
             out: *mut *mut OrtValue,
         ) -> OrtStatusPtr,
     >,
@@ -3800,7 +3795,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             arg1: *const OrtTypeInfo,
             denotation: *mut *const ::std::os::raw::c_char,
-            len: *mut size_t,
+            len: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub CastTypeInfoToMapTypeInfo: ::std::option::Option<
@@ -3937,17 +3932,13 @@ pub struct OrtApi {
         ) -> OrtStatusPtr,
     >,
     pub GetStringTensorElementLength: ::std::option::Option<
-        unsafe extern "C" fn(
-            value: *const OrtValue,
-            index: size_t,
-            out: *mut size_t,
-        ) -> OrtStatusPtr,
+        unsafe extern "C" fn(value: *const OrtValue, index: usize, out: *mut usize) -> OrtStatusPtr,
     >,
     pub GetStringTensorElement: ::std::option::Option<
         unsafe extern "C" fn(
             value: *const OrtValue,
-            s_len: size_t,
-            index: size_t,
+            s_len: usize,
+            index: usize,
             s: *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -3955,7 +3946,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             value: *mut OrtValue,
             s: *const ::std::os::raw::c_char,
-            index: size_t,
+            index: usize,
         ) -> OrtStatusPtr,
     >,
     pub AddSessionConfigEntry: ::std::option::Option<
@@ -4010,8 +4001,8 @@ pub struct OrtApi {
             binding_ptr: *const OrtIoBinding,
             allocator: *mut OrtAllocator,
             buffer: *mut *mut ::std::os::raw::c_char,
-            lengths: *mut *mut size_t,
-            count: *mut size_t,
+            lengths: *mut *mut usize,
+            count: *mut usize,
         ) -> OrtStatusPtr,
     >,
     pub GetBoundOutputValues: ::std::option::Option<
@@ -4019,7 +4010,7 @@ pub struct OrtApi {
             binding_ptr: *const OrtIoBinding,
             allocator: *mut OrtAllocator,
             output: *mut *mut *mut OrtValue,
-            output_count: *mut size_t,
+            output_count: *mut usize,
         ) -> OrtStatusPtr,
     >,
     #[doc = " Clears any previously specified bindings for inputs/outputs"]
@@ -4031,7 +4022,7 @@ pub struct OrtApi {
         unsafe extern "C" fn(
             value: *mut OrtValue,
             location_values: *const i64,
-            location_values_count: size_t,
+            location_values_count: usize,
             out: *mut *mut ::std::os::raw::c_void,
         ) -> OrtStatusPtr,
     >,
@@ -4103,7 +4094,7 @@ pub struct OrtApi {
     >,
     pub CreateArenaCfg: ::std::option::Option<
         unsafe extern "C" fn(
-            max_mem: size_t,
+            max_mem: usize,
             arena_extend_strategy: ::std::os::raw::c_int,
             initial_chunk_size_bytes: ::std::os::raw::c_int,
             max_dead_bytes_per_chunk: ::std::os::raw::c_int,
@@ -5807,15 +5798,15 @@ pub struct OrtCustomOp {
         unsafe extern "C" fn(op: *const OrtCustomOp) -> *const ::std::os::raw::c_char,
     >,
     pub GetInputType: ::std::option::Option<
-        unsafe extern "C" fn(op: *const OrtCustomOp, index: size_t) -> ONNXTensorElementDataType,
+        unsafe extern "C" fn(op: *const OrtCustomOp, index: usize) -> ONNXTensorElementDataType,
     >,
     pub GetInputTypeCount:
-        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> size_t>,
+        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> usize>,
     pub GetOutputType: ::std::option::Option<
-        unsafe extern "C" fn(op: *const OrtCustomOp, index: size_t) -> ONNXTensorElementDataType,
+        unsafe extern "C" fn(op: *const OrtCustomOp, index: usize) -> ONNXTensorElementDataType,
     >,
     pub GetOutputTypeCount:
-        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> size_t>,
+        ::std::option::Option<unsafe extern "C" fn(op: *const OrtCustomOp) -> usize>,
     pub KernelCompute: ::std::option::Option<
         unsafe extern "C" fn(
             op_kernel: *mut ::std::os::raw::c_void,

--- a/onnxruntime/src/environment.rs
+++ b/onnxruntime/src/environment.rs
@@ -322,7 +322,7 @@ mod tests {
 
         let initial_name = String::from("concurrent_environment_creation");
         let main_env = Environment::new(initial_name.clone(), LoggingLevel::Warning).unwrap();
-        let main_env_ptr = main_env.env_ptr() as u64;
+        let main_env_ptr = main_env.env_ptr() as usize;
 
         let children: Vec<_> = (0..10)
             .map(|t| {
@@ -336,13 +336,13 @@ mod tests {
                         .unwrap();
 
                     assert_eq!(env.name(), initial_name_cloned);
-                    assert_eq!(env.env_ptr() as u64, main_env_ptr);
+                    assert_eq!(env.env_ptr() as usize, main_env_ptr);
                 })
             })
             .collect();
 
         assert_eq!(main_env.name(), initial_name);
-        assert_eq!(main_env.env_ptr() as u64, main_env_ptr);
+        assert_eq!(main_env.env_ptr() as usize, main_env_ptr);
 
         let res: Vec<std::thread::Result<_>> =
             children.into_iter().map(|child| child.join()).collect();

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -585,7 +585,7 @@ mod dangerous {
     }
 
     fn extract_io_count(
-        f: unsafe extern "C" fn(*const sys::OrtSession, *mut usize) -> *mut sys::OrtStatus,
+        f: extern_system_fn! { unsafe fn(*const sys::OrtSession, *mut usize) -> *mut sys::OrtStatus },
         session_ptr: *mut sys::OrtSession,
     ) -> Result<usize> {
         let mut num_nodes: usize = 0;
@@ -615,12 +615,12 @@ mod dangerous {
     }
 
     fn extract_io_name(
-        f: unsafe extern "C" fn(
+        f: extern_system_fn! { unsafe fn(
             *const sys::OrtSession,
             usize,
             *mut sys::OrtAllocator,
             *mut *mut i8,
-        ) -> *mut sys::OrtStatus,
+        ) -> *mut sys::OrtStatus },
         session_ptr: *mut sys::OrtSession,
         allocator_ptr: *mut sys::OrtAllocator,
         i: usize,
@@ -668,11 +668,11 @@ mod dangerous {
     }
 
     fn extract_io(
-        f: unsafe extern "C" fn(
+        f: extern_system_fn! { unsafe fn(
             *const sys::OrtSession,
             usize,
             *mut *mut sys::OrtTypeInfo,
-        ) -> *mut sys::OrtStatus,
+        ) -> *mut sys::OrtStatus },
         session_ptr: *mut sys::OrtSession,
         i: usize,
     ) -> Result<(TensorElementDataType, Vec<Option<u32>>)> {

--- a/onnxruntime/src/tensor/ort_tensor.rs
+++ b/onnxruntime/src/tensor/ort_tensor.rs
@@ -50,7 +50,7 @@ where
 
         let shape: Vec<i64> = array.shape().iter().map(|d: &usize| *d as i64).collect();
         let shape_ptr: *const i64 = shape.as_ptr();
-        let shape_len = array.shape().len() as u64;
+        let shape_len = array.shape().len();
 
         match T::tensor_element_data_type() {
             TensorElementDataType::Float
@@ -74,7 +74,7 @@ where
                         ort.CreateTensorWithDataAsOrtValue.unwrap()(
                             memory_info.ptr,
                             tensor_values_ptr,
-                            (array.len() * std::mem::size_of::<T>()) as u64,
+                            array.len() * std::mem::size_of::<T>(),
                             shape_ptr,
                             shape_len,
                             T::tensor_element_data_type().into(),
@@ -126,7 +126,7 @@ where
                         ort.FillStringTensor.unwrap()(
                             tensor_ptr,
                             string_pointers.as_ptr(),
-                            string_pointers.len() as u64,
+                            string_pointers.len(),
                         )
                     })
                 }


### PR DESCRIPTION
Recently, I had to use `onnxruntime` crate on Windows 32bit but it doesn't seem to work  because there are some mismatched types & function calling conventions between `onnxruntime-sys` and `onnxruntime`. So I fixed the binding generation config to use `usize` instead of `u64`,  and added macros for choosing appropriate function calling conventions according to the target architecture, and also re-enabled CI for `i686`.