### PR TITLE
Fix compilation errors in tests

### DIFF
--- a/onnxruntime/tests/integration_tests.rs
+++ b/onnxruntime/tests/integration_tests.rs
@@ -104,7 +104,6 @@ mod download {
         let mut probabilities: Vec<(usize, f32)> = outputs[0]
             .softmax(ndarray::Axis(1))
             .into_iter()
-            .copied()
             .enumerate()
             .collect::<Vec<_>>();
         // Sort probabilities so highest is at beginning of vector.
@@ -193,7 +192,6 @@ mod download {
         let mut probabilities: Vec<(usize, f32)> = outputs[0]
             .softmax(ndarray::Axis(1))
             .into_iter()
-            .copied()
             .enumerate()
             .collect::<Vec<_>>();
 

--- a/onnxruntime/tests/integration_tests.rs
+++ b/onnxruntime/tests/integration_tests.rs
@@ -103,7 +103,8 @@ mod download {
         // and iterate on resulting probabilities, creating an index to later access labels.
         let mut probabilities: Vec<(usize, f32)> = outputs[0]
             .softmax(ndarray::Axis(1))
-            .into_iter()
+            .iter()
+            .copied()
             .enumerate()
             .collect::<Vec<_>>();
         // Sort probabilities so highest is at beginning of vector.
@@ -191,7 +192,8 @@ mod download {
 
         let mut probabilities: Vec<(usize, f32)> = outputs[0]
             .softmax(ndarray::Axis(1))
-            .into_iter()
+            .iter()
+            .copied()
             .enumerate()
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
See rust-ndarray/ndarray#1051. I think these changes will fix the errors, but I haven't tested them. An alternative would be to change `.into_iter()` to `.iter()`; I'm not sure which approach is better.