### PR TITLE
Fix link in docs

### DIFF
--- a/onnxruntime/src/lib.rs
+++ b/onnxruntime/src/lib.rs
@@ -109,7 +109,7 @@ to download.
 //! # }
 //! ```
 //!
-//! The outputs are of type [`OrtOwnedTensor`](tensor/struct.OrtOwnedTensor.html)s inside a vector,
+//! The outputs are of type [`OrtOwnedTensor`](tensor/ort_owned_tensor/struct.OrtOwnedTensor.html)s inside a vector,
 //! with the same length as the inputs.
 //!
 //! See the [`sample.rs`](https://github.com/nbigaouette/onnxruntime-rs/blob/master/onnxruntime/examples/sample.rs)


### PR DESCRIPTION
Currently the OrtOwnedTensor-link from [here](https://docs.rs/onnxruntime/latest/onnxruntime/index.html) goes to https://docs.rs/onnxruntime/latest/onnxruntime/tensor/struct.OrtOwnedTensor.html which is dead, should go to https://docs.rs/onnxruntime/latest/onnxruntime/tensor/ort_owned_tensor/struct.OrtOwnedTensor.html