### PR TITLE
Bump zip to get a newer version of time

### DIFF
--- a/onnxruntime-sys/Cargo.toml
+++ b/onnxruntime-sys/Cargo.toml
@@ -21,7 +21,7 @@ bindgen = { version = "0.59", optional = true }
 ureq = "2.1"
 
 # Used on Windows
-zip = "0.5"
+zip = "0.6"
 
 # Used on unix
 flate2 = "1.0"


### PR DESCRIPTION
Update `zip` to get a newer version of `time`.

`zip 0.5.x` depends on an old version of `time` that is affected by https://rustsec.org/advisories/RUSTSEC-2020-0071