### PR TITLE
bump to 1.14.1 and support Apple M1

### DIFF
--- a/onnxruntime-sys/build.rs
+++ b/onnxruntime-sys/build.rs
@@ -13,7 +13,7 @@ use std::{
 /// WARNING: If version is changed, bindings for all platforms will have to be re-generated.
 ///          To do so, run this:
 ///              cargo build --package onnxruntime-sys --features generate-bindings
-const ORT_VERSION: &str = "1.8.1";
+const ORT_VERSION: &str = "1.14.1";
 
 /// Base Url from which to download pre-built releases/
 const ORT_RELEASE_BASE_URL: &str = "https://github.com/microsoft/onnxruntime/releases/download";
@@ -310,12 +310,12 @@ struct Triplet {
 impl OnnxPrebuiltArchive for Triplet {
     fn as_onnx_str(&self) -> Cow<str> {
         match (&self.os, &self.arch, &self.accelerator) {
-            // onnxruntime-win-x86-1.8.1.zip
-            // onnxruntime-win-x64-1.8.1.zip
-            // onnxruntime-win-arm-1.8.1.zip
-            // onnxruntime-win-arm64-1.8.1.zip
-            // onnxruntime-linux-x64-1.8.1.tgz
-            // onnxruntime-osx-x64-1.8.1.tgz
+            // onnxruntime-win-x86-1.14.1.zip
+            // onnxruntime-win-x64-1.14.1.zip
+            // onnxruntime-win-arm-1.14.1.zip
+            // onnxruntime-win-arm64-1.14.1.zip
+            // onnxruntime-linux-x64-1.14.1.tgz
+            // onnxruntime-osx-x64-1.14.1.tgz
             (Os::Windows, Architecture::X86, Accelerator::None)
             | (Os::Windows, Architecture::X86_64, Accelerator::None)
             | (Os::Windows, Architecture::Arm, Accelerator::None)
@@ -326,7 +326,13 @@ impl OnnxPrebuiltArchive for Triplet {
                 self.os.as_onnx_str(),
                 self.arch.as_onnx_str()
             )),
-            // onnxruntime-win-gpu-x64-1.8.1.zip
+            // onnxruntime-osx-arm64-1.14.1.tgz
+            (Os::MacOs, Architecture::Arm64, Accelerator::None) => Cow::from(format!(
+                "{}-{}",
+                self.os.as_onnx_str(),
+                self.arch.as_onnx_str(),
+            )),
+            // onnxruntime-win-gpu-x64-1.14.1.zip
             // Note how this one is inverted from the linux one next
             (Os::Windows, Architecture::X86_64, Accelerator::Gpu) => Cow::from(format!(
                 "{}-{}-{}",
@@ -334,7 +340,7 @@ impl OnnxPrebuiltArchive for Triplet {
                 self.accelerator.as_onnx_str(),
                 self.arch.as_onnx_str(),
             )),
-            // onnxruntime-linux-x64-gpu-1.8.1.tgz
+            // onnxruntime-linux-x64-gpu-1.14.1.tgz
             // Note how this one is inverted from the windows one above
             (Os::Linux, Architecture::X86_64, Accelerator::Gpu) => Cow::from(format!(
                 "{}-{}-{}",

--- a/onnxruntime-sys/src/lib.rs
+++ b/onnxruntime-sys/src/lib.rs
@@ -5,8 +5,6 @@
 #![allow(clippy::all)]
 #![allow(improper_ctypes)]
 
-#[allow(clippy::all)]
-
 include!(concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/src/generated/bindings.rs"

--- a/onnxruntime/src/session.rs
+++ b/onnxruntime/src/session.rs
@@ -296,6 +296,7 @@ impl<'a> SessionBuilder<'a> {
 /// Type storing the session information, built from an [`Environment`](environment/struct.Environment.html)
 #[derive(Debug)]
 pub struct Session<'a> {
+    #[allow(dead_code)]
     env: &'a Environment,
     session_ptr: *mut sys::OrtSession,
     allocator_ptr: *mut sys::OrtAllocator,

--- a/onnxruntime/src/tensor/ort_owned_tensor.rs
+++ b/onnxruntime/src/tensor/ort_owned_tensor.rs
@@ -31,6 +31,7 @@ where
 {
     pub(crate) tensor_ptr: *mut sys::OrtValue,
     array_view: ArrayView<'t, T, D>,
+    #[allow(dead_code)]
     memory_info: &'m MemoryInfo,
 }
 

--- a/onnxruntime/src/tensor/ort_tensor.rs
+++ b/onnxruntime/src/tensor/ort_tensor.rs
@@ -30,6 +30,7 @@ where
 {
     pub(crate) c_ptr: *mut sys::OrtValue,
     array: Array<T, D>,
+    #[allow(dead_code)]
     memory_info: &'t MemoryInfo,
 }
 


### PR DESCRIPTION
onnxruntime v1.14.1 now supports M1 with a precompiled binary 

https://github.com/microsoft/onnxruntime/releases

This PR bumps the version and adds the binary so it can be auto downloaded (avoid compile step)